### PR TITLE
Add individual startup scripts

### DIFF
--- a/run_backend.py
+++ b/run_backend.py
@@ -1,0 +1,20 @@
+import subprocess
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parent
+BACKEND_DIR = ROOT / "osarebito-backend"
+BACKEND_UVICORN = BACKEND_DIR / "venv" / "bin" / "uvicorn"
+
+
+def main() -> None:
+    """Start the FastAPI backend with Uvicorn."""
+    if BACKEND_UVICORN.exists():
+        cmd = [str(BACKEND_UVICORN), "app.main:app", "--reload"]
+    else:
+        cmd = [sys.executable, "-m", "uvicorn", "app.main:app", "--reload"]
+    subprocess.run(cmd, cwd=BACKEND_DIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_frontend.py
+++ b/run_frontend.py
@@ -1,0 +1,18 @@
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+FRONTEND_DIR = ROOT / "osarebito-frontend"
+
+
+def main() -> None:
+    """Start the Next.js development server."""
+    cmd = ["npm", "run", "dev"]
+    if os.name == "nt":
+        cmd[0] = "npm.cmd"  # Ensure Windows finds npm
+    subprocess.run(cmd, cwd=FRONTEND_DIR)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide standalone scripts for front‑end and back‑end startup

## Testing
- `python3 -m py_compile run_frontend.py run_backend.py`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ef9f95450832d84c25f6a2a60c867