### PR TITLE
Fix run_frontend helper

### DIFF
--- a/run_frontend.bat
+++ b/run_frontend.bat
@@ -1,0 +1,4 @@
+@echo off
+set SCRIPT_DIR=%~dp0
+cd /d "%SCRIPT_DIR%osarebito-frontend"
+npm run dev

--- a/run_frontend.py
+++ b/run_frontend.py
@@ -1,5 +1,7 @@
 import os
 import subprocess
+import shutil
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent
@@ -8,10 +10,13 @@ FRONTEND_DIR = ROOT / "osarebito-frontend"
 
 def main() -> None:
     """Start the Next.js development server."""
-    cmd = ["npm", "run", "dev"]
-    if os.name == "nt":
-        cmd[0] = "npm.cmd"  # Ensure Windows finds npm
-    subprocess.run(cmd, cwd=FRONTEND_DIR)
+    # Find npm (or npm.cmd on Windows) in PATH
+    npm = shutil.which("npm") or shutil.which("npm.cmd")
+    if not npm:
+        sys.stderr.write("npm was not found. Please install Node.js and ensure npm is available in PATH.\n")
+        sys.exit(1)
+
+    subprocess.run([npm, "run", "dev"], cwd=FRONTEND_DIR)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- improve `run_frontend.py` to show an informative error if npm isn't found
- add `run_frontend.bat` so Windows users can start the frontend directly

## Testing
- `python -m py_compile run_frontend.py`

------
https://chatgpt.com/codex/tasks/task_e_687efc05ee44832d9125903dc3f065a6