### PR TITLE
Modify AI noise overlay

### DIFF
--- a/osarebito-frontend/src/app/imagetool/page.tsx
+++ b/osarebito-frontend/src/app/imagetool/page.tsx
@@ -47,12 +47,13 @@ async function compressImage(file: File, ai: boolean): Promise<Blob> {
       d[i + 1] = clamp(d[i + 1] + rand(-5, 5)) // Green channel
       d[i + 2] = clamp(d[i + 2] + rand(-5, 5)) // Blue channel
     }
-    // Add larger random noise at intervals
+    // Add larger random noise at intervals with some transparency
+    const dotOpacity = 0.3 // 0 = transparent, 1 = opaque
     for (let i = 0; i < d.length; i += 40) { // Every 10 pixels (40 bytes)
       const noise = rand(0, 255) // Random grayscale noise
-      d[i] = noise
-      d[i + 1] = noise
-      d[i + 2] = noise
+      d[i] = clamp(d[i] * (1 - dotOpacity) + noise * dotOpacity)
+      d[i + 1] = clamp(d[i + 1] * (1 - dotOpacity) + noise * dotOpacity)
+      d[i + 2] = clamp(d[i + 2] * (1 - dotOpacity) + noise * dotOpacity)
     }
     // Put the modified image data back onto the canvas
     ctx.putImageData(imageData, 0, 0)


### PR DESCRIPTION
## Summary
- lighten AI countermeasure dots for image compression tool

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688033d4e13c832d9593012f1e9733fc