### PR TITLE
Implement user profiles

### DIFF
--- a/osarebito-backend/app/main.py
+++ b/osarebito-backend/app/main.py
@@ -37,7 +37,7 @@ def register(user: User):
     users = load_users()
     if any(u["user_id"] == user.user_id for u in users):
         raise HTTPException(status_code=400, detail="User ID already exists")
-    users.append(user.dict())
+    users.append({**user.dict(), "profile": {}})
     save_users(users)
     return {"message": "registered"}
 
@@ -54,3 +54,56 @@ def login(data: LoginInput):
         if u["user_id"] == data.user_id and u["password"] == data.password:
             return {"message": "logged in"}
     raise HTTPException(status_code=401, detail="Invalid credentials")
+
+
+class Profile(BaseModel):
+    profile_image: str | None = None
+    bio: str | None = None
+    activity: str | None = None
+    sns_links: dict | None = None
+    visibility: str = "public"
+
+
+class ProfileUpdate(BaseModel):
+    profile_image: str | None = None
+    bio: str | None = None
+    activity: str | None = None
+    sns_links: dict | None = None
+    visibility: str | None = None
+
+
+def remove_password(user: dict) -> dict:
+    u = user.copy()
+    u.pop("password", None)
+    return u
+
+
+@app.get("/users/{user_id}")
+def get_user(user_id: str):
+    users = load_users()
+    for u in users:
+        if u["user_id"] == user_id:
+            return remove_password(u)
+    raise HTTPException(status_code=404, detail="User not found")
+
+
+@app.get("/users/search")
+def search_users(query: str):
+    users = load_users()
+    query_lower = query.lower()
+    result = [remove_password(u) for u in users if query_lower in u["user_id"].lower() or query_lower in u["username"].lower()]
+    return result
+
+
+@app.put("/users/{user_id}/profile")
+def update_profile(user_id: str, profile: ProfileUpdate):
+    users = load_users()
+    for u in users:
+        if u["user_id"] == user_id:
+            prof = u.get("profile", {})
+            data = profile.dict(exclude_unset=True)
+            prof.update({k: v for k, v in data.items() if v is not None})
+            u["profile"] = prof
+            save_users(users)
+            return {"message": "updated"}
+    raise HTTPException(status_code=404, detail="User not found")

--- a/osarebito-frontend/src/app/api/users/[userId]/profile/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/profile/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  try {
+    const data = await req.json()
+    const res = await fetch(`http://localhost:8000/users/${params.userId}/profile`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    return NextResponse.json(body, { status: res.status })
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/users/[userId]/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  try {
+    const res = await fetch(`http://localhost:8000/users/${params.userId}`)
+    const body = await res.json()
+    return NextResponse.json(body, { status: res.status })
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/users/search/route.ts
+++ b/osarebito-frontend/src/app/api/users/search/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const query = searchParams.get('query') || ''
+    const res = await fetch(`http://localhost:8000/users/search?query=${encodeURIComponent(query)}`)
+    const body = await res.json()
+    return NextResponse.json(body, { status: res.status })
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/login/page.tsx
+++ b/osarebito-frontend/src/app/login/page.tsx
@@ -19,6 +19,7 @@ export default function Login() {
       })
       if (res.status === 200) {
         localStorage.setItem('loggedIn', 'true')
+        localStorage.setItem('userId', userId)
         setMessage('Logged in')
         router.push('/')
       }

--- a/osarebito-frontend/src/app/page.tsx
+++ b/osarebito-frontend/src/app/page.tsx
@@ -4,14 +4,18 @@ import Link from 'next/link'
 
 export default function Home() {
   const [loggedIn, setLoggedIn] = useState(false)
+  const [userId, setUserId] = useState('')
 
   useEffect(() => {
     setLoggedIn(localStorage.getItem('loggedIn') === 'true')
+    setUserId(localStorage.getItem('userId') || '')
   }, [])
 
   const handleLogout = () => {
     localStorage.removeItem('loggedIn')
+    localStorage.removeItem('userId')
     setLoggedIn(false)
+    setUserId('')
   }
 
   return (
@@ -40,6 +44,25 @@ export default function Home() {
           画像圧縮ツール
         </Link>
       </div>
+      <div className="mt-2">
+        <Link href="/profile/search" className="text-blue-500 underline">
+          ユーザー検索
+        </Link>
+      </div>
+      {loggedIn && (
+        <>
+          <div className="mt-2">
+            <Link href={`/profile/${userId}`} className="text-blue-500 underline">
+              プロフィール
+            </Link>
+          </div>
+          <div className="mt-2">
+            <Link href="/profile/settings" className="text-blue-500 underline">
+              プロフィール設定
+            </Link>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/osarebito-frontend/src/app/profile/[userId]/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/page.tsx
@@ -1,0 +1,37 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+
+interface UserProfile {
+  user_id: string
+  username: string
+  role: string
+  profile?: {
+    bio?: string
+    activity?: string
+  }
+}
+
+export default function ProfilePage({ params }: { params: { userId: string } }) {
+  const [user, setUser] = useState<UserProfile | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await axios.get(`/api/users/${params.userId}`)
+      setUser(res.data)
+    }
+    load()
+  }, [params.userId])
+
+  if (!user) return <div className="max-w-md mx-auto mt-10">Loading...</div>
+  const p = user.profile || {}
+  return (
+    <div className="max-w-md mx-auto mt-10">
+      <h1 className="text-2xl font-bold mb-4">{user.username}のプロフィール</h1>
+      <p>User ID: {user.user_id}</p>
+      <p>Role: {user.role}</p>
+      {p.bio && <p className="mt-2">Bio: {p.bio}</p>}
+      {p.activity && <p className="mt-2">Activity: {p.activity}</p>}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/profile/search/page.tsx
+++ b/osarebito-frontend/src/app/profile/search/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+import { useState } from 'react'
+import axios from 'axios'
+import Link from 'next/link'
+
+interface SearchUser {
+  user_id: string
+  username: string
+}
+
+export default function ProfileSearch() {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<SearchUser[]>([])
+
+  const handleSearch = async () => {
+    const res = await axios.get('/api/users/search', { params: { query } })
+    setResults(res.data)
+  }
+
+  return (
+    <div className="max-w-md mx-auto mt-10 flex flex-col gap-4">
+      <h1 className="text-2xl font-bold">ユーザー検索</h1>
+      <input
+        className="border p-2"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search users"
+      />
+      <button className="bg-blue-500 text-white py-2" onClick={handleSearch}>
+        Search
+      </button>
+      <ul className="list-disc pl-5">
+        {results.map((u) => (
+          <li key={u.user_id}>
+            <Link href={`/profile/${u.user_id}`} className="text-blue-500 underline">
+              {u.username} ({u.user_id})
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/profile/settings/page.tsx
+++ b/osarebito-frontend/src/app/profile/settings/page.tsx
@@ -1,0 +1,54 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import { useRouter } from 'next/navigation'
+
+export default function ProfileSettings() {
+  const [bio, setBio] = useState('')
+  const [activity, setActivity] = useState('')
+  const [message, setMessage] = useState('')
+  const [userId, setUserId] = useState<string | null>(null)
+  const router = useRouter()
+
+  useEffect(() => {
+    const id = localStorage.getItem('userId')
+    if (!id) {
+      router.push('/login')
+      return
+    }
+    setUserId(id)
+    axios.get(`/api/users/${id}`).then((res) => {
+      const p = res.data.profile || {}
+      setBio(p.bio || '')
+      setActivity(p.activity || '')
+    })
+  }, [router])
+
+  const handleSave = async () => {
+    if (!userId) return
+    await axios.put(`/api/users/${userId}/profile`, { bio, activity })
+    setMessage('Saved')
+  }
+
+  return (
+    <div className="max-w-md mx-auto mt-10 flex flex-col gap-4">
+      <h1 className="text-2xl font-bold">プロフィール設定</h1>
+      <textarea
+        className="border p-2"
+        placeholder="Bio"
+        value={bio}
+        onChange={(e) => setBio(e.target.value)}
+      />
+      <textarea
+        className="border p-2"
+        placeholder="Activity"
+        value={activity}
+        onChange={(e) => setActivity(e.target.value)}
+      />
+      <button className="bg-blue-500 text-white py-2" onClick={handleSave}>
+        Save
+      </button>
+      {message && <p>{message}</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- support profiles in FastAPI backend
- store userId on login
- add profile links on top page
- enable searching for users
- allow editing/viewing profiles on frontend

## Testing
- `npm run lint`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688049fed4ec832d96160464407824f5