### PR TITLE
Add profile view and edit pages

### DIFF
--- a/osarebito-frontend/src/app/api/users/[userId]/profile/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/profile/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function PUT(req: NextRequest, { params }: { params: { userId: string } }) {
+  try {
+    const data = await req.json()
+    const res = await fetch(`http://localhost:8000/users/${params.userId}/profile`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/users/[userId]/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(_req: NextRequest, { params }: { params: { userId: string } }) {
+  try {
+    const res = await fetch(`http://localhost:8000/users/${params.userId}`)
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/profile/[userId]/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/page.tsx
@@ -1,0 +1,29 @@
+import Image from 'next/image'
+
+async function getUser(userId: string) {
+  const res = await fetch(`http://localhost:3000/api/users/${userId}`, { cache: 'no-store' })
+  if (!res.ok) {
+    return null
+  }
+  return res.json()
+}
+
+export default async function Profile({ params }: { params: { userId: string } }) {
+  const user = await getUser(params.userId)
+  if (!user) {
+    return <div className="max-w-md mx-auto mt-10">ユーザーが見つかりません</div>
+  }
+  const profile = user.profile || {}
+  return (
+    <div className="max-w-md mx-auto mt-10 flex flex-col gap-2">
+      <h1 className="text-2xl font-bold mb-4">プロフィール</h1>
+      <p>User ID: {user.user_id}</p>
+      <p>Username: {user.username}</p>
+      {profile.profile_image && (
+        <Image src={profile.profile_image} alt="profile" width={200} height={200} className="mt-2" />
+      )}
+      {profile.bio && <p className="mt-2">{profile.bio}</p>}
+      {profile.activity && <p className="mt-2">{profile.activity}</p>}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/profile/settings/page.tsx
+++ b/osarebito-frontend/src/app/profile/settings/page.tsx
@@ -1,0 +1,91 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+
+export default function ProfileSettings() {
+  const [profileImage, setProfileImage] = useState('')
+  const [bio, setBio] = useState('')
+  const [activity, setActivity] = useState('')
+  const [visibility, setVisibility] = useState('public')
+  const [message, setMessage] = useState('')
+  const [userId, setUserId] = useState('')
+
+  useEffect(() => {
+    const id = localStorage.getItem('userId') || ''
+    setUserId(id)
+    if (!id) return
+    axios.get(`/api/users/${id}`).then((res) => {
+      const prof = res.data.profile || {}
+      setProfileImage(prof.profile_image || '')
+      setBio(prof.bio || '')
+      setActivity(prof.activity || '')
+      setVisibility(prof.visibility || 'public')
+    }).catch(() => setMessage('Error loading'))
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      const res = await axios.put(`/api/users/${userId}/profile`, {
+        profile_image: profileImage,
+        bio,
+        activity,
+        visibility,
+      })
+      if (res.status === 200) {
+        setMessage('更新しました')
+      }
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'response' in err) {
+        const anyErr = err as { response?: { data?: { detail?: string } } }
+        setMessage(anyErr.response?.data?.detail || 'Error')
+      } else {
+        setMessage('Error')
+      }
+    }
+  }
+
+  if (!userId) {
+    return <div className="max-w-md mx-auto mt-10">ログインしてください</div>
+  }
+
+  return (
+    <div className="max-w-md mx-auto mt-10">
+      <h1 className="text-2xl font-bold mb-4">プロフィール設定</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <input
+          className="border p-2"
+          type="text"
+          placeholder="画像URL"
+          value={profileImage}
+          onChange={(e) => setProfileImage(e.target.value)}
+        />
+        <textarea
+          className="border p-2"
+          placeholder="自己紹介"
+          value={bio}
+          onChange={(e) => setBio(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          type="text"
+          placeholder="活動内容"
+          value={activity}
+          onChange={(e) => setActivity(e.target.value)}
+        />
+        <select
+          className="border p-2"
+          value={visibility}
+          onChange={(e) => setVisibility(e.target.value)}
+        >
+          <option value="public">公開</option>
+          <option value="private">非公開</option>
+        </select>
+        <button className="bg-blue-500 text-white py-2" type="submit">
+          保存
+        </button>
+      </form>
+      {message && <p className="mt-4">{message}</p>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add backend API wrappers for getting and updating a user
- add profile edit page
- add profile display page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688075a25080832db651bd0f1d0d4934