### PR TITLE
Add basic profile display page

### DIFF
--- a/osarebito-frontend/src/app/profile/[userId]/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/page.tsx
@@ -1,0 +1,30 @@
+import Image from 'next/image'
+import { getUserUrl } from '../../../routs'
+
+async function getUser(userId: string) {
+  const res = await fetch(getUserUrl(userId), { cache: 'no-store' })
+  if (!res.ok) {
+    return null
+  }
+  return res.json()
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default async function Profile({ params }: any) {
+  const user = await getUser(params.userId)
+  if (!user) {
+    return <div className="max-w-md mx-auto mt-10">ユーザーが見つかりません</div>
+  }
+  const profile = user.profile || {}
+  return (
+    <div className="max-w-md mx-auto mt-10 flex flex-col gap-2">
+      <h1 className="text-2xl font-bold mb-4">プロフィール</h1>
+      <p>User ID: {user.user_id}</p>
+      <p>Username: {user.username}</p>
+      {profile.profile_image && (
+        <Image src={profile.profile_image} alt="profile" width={200} height={200} className="mt-2" />
+      )}
+      {profile.bio && <p className="mt-2">{profile.bio}</p>}
+      {profile.activity && <p className="mt-2">{profile.activity}</p>}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/routs.ts
+++ b/osarebito-frontend/src/routs.ts
@@ -1,0 +1,3 @@
+export const BACKEND_URL = 'http://localhost:8000'
+export const getUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}`
+export const updateProfileUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/profile`


### PR DESCRIPTION
## Summary
- implement a simple profile page
- store backend endpoints in `routs.ts`
- provide lint and build

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688078640480832d9eb58f57499de011