### PR TITLE
Add profile update API route

### DIFF
--- a/osarebito-frontend/src/app/api/users/[userId]/profile/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/profile/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { updateProfileUrl } from '../../../../routs'
+
+export async function PUT(req: NextRequest, { params }: { params: { userId: string } }) {
+  try {
+    const data = await req.json()
+    const res = await fetch(updateProfileUrl(params.userId), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add API route to update user profile from the frontend

## Testing
- `npm run lint`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688085534f74832dad234e13d77f0348