### PR TITLE
Add user profile update API route

### DIFF
--- a/osarebito-frontend/src/app/api/users/[userId]/profile/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/profile/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { updateProfileUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function PUT(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const userId = Array.isArray(params.userId)
+      ? params.userId[0]
+      : params.userId
+    const res = await fetch(updateProfileUrl(userId), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- ユーザープロフィール更新用のAPIルートを新規作成
- ルートのパスと型定義を修正

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6880874d954c832da2d70ed8499ca700