### PR TITLE
Fix missing search page

### DIFF
--- a/osarebito-frontend/src/app/api/users/search/route.ts
+++ b/osarebito-frontend/src/app/api/users/search/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { searchUsersUrl } from '../../../../routs'
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const query = searchParams.get('query') || ''
+    const res = await fetch(searchUsersUrl(query))
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/profile/search/page.tsx
+++ b/osarebito-frontend/src/app/profile/search/page.tsx
@@ -1,0 +1,62 @@
+'use client'
+import { useState } from 'react'
+
+interface SearchResult {
+  user_id: string
+  username: string
+}
+import Link from 'next/link'
+
+export default function ProfileSearch() {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [message, setMessage] = useState('')
+
+  const handleSearch = async () => {
+    if (!query) return
+    try {
+      const res = await fetch(`/api/users/search?query=${encodeURIComponent(query)}`)
+      const data = await res.json()
+      if (!res.ok) {
+        setMessage(data.detail || 'Error')
+        setResults([])
+      } else {
+        setResults(data)
+        setMessage('')
+      }
+    } catch {
+      setMessage('Error')
+      setResults([])
+    }
+  }
+
+  return (
+    <div className="max-w-md mx-auto mt-10 flex flex-col gap-4">
+      <h1 className="text-2xl font-bold">ユーザー検索</h1>
+      <div className="flex gap-2">
+        <input
+          className="border p-2 flex-1"
+          type="text"
+          placeholder="検索ワード"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <button className="bg-blue-500 text-white px-4" onClick={handleSearch}>
+          検索
+        </button>
+      </div>
+      {message && <p>{message}</p>}
+      {results.length > 0 && (
+        <ul className="list-disc pl-5">
+          {results.map((u) => (
+            <li key={u.user_id} className="mt-2">
+              <Link href={`/profile/${u.user_id}`} className="text-blue-500 underline">
+                {u.username}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/routs.ts
+++ b/osarebito-frontend/src/routs.ts
@@ -1,3 +1,4 @@
 export const BACKEND_URL = 'http://localhost:8000'
 export const getUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}`
 export const updateProfileUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/profile`
+export const searchUsersUrl = (query: string) => `${BACKEND_URL}/users/search?query=${encodeURIComponent(query)}`


### PR DESCRIPTION
## Summary
- add searchUsersUrl to central router list
- implement user search API route
- create user search page with type fixes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688089c1f89c832d91ce440586bed3c7