### PR TITLE
プロフィール設定画面の拡充

### DIFF
--- a/osarebito-frontend/src/app/profile/[userId]/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/page.tsx
@@ -25,6 +25,23 @@ export default async function Profile({ params }: any) {
       )}
       {profile.bio && <p className="mt-2">{profile.bio}</p>}
       {profile.activity && <p className="mt-2">{profile.activity}</p>}
+      {profile.sns_links && (
+        <div className="mt-2 flex flex-col gap-1">
+          {profile.sns_links.youtube && (
+            <a href={profile.sns_links.youtube} className="text-blue-500 underline">
+              YouTube
+            </a>
+          )}
+          {profile.sns_links.twitter && (
+            <a href={profile.sns_links.twitter} className="text-blue-500 underline">
+              Twitter
+            </a>
+          )}
+        </div>
+      )}
+      {profile.visibility && (
+        <p className="mt-2 text-sm text-gray-600">公開範囲: {profile.visibility}</p>
+      )}
     </div>
   )
 }

--- a/osarebito-frontend/src/app/profile/settings/page.tsx
+++ b/osarebito-frontend/src/app/profile/settings/page.tsx
@@ -6,6 +6,11 @@ import { useRouter } from 'next/navigation'
 
 export default function ProfileSettings() {
   const [bio, setBio] = useState('')
+  const [profileImage, setProfileImage] = useState('')
+  const [activity, setActivity] = useState('')
+  const [youtube, setYoutube] = useState('')
+  const [twitter, setTwitter] = useState('')
+  const [visibility, setVisibility] = useState('public')
   const [message, setMessage] = useState('')
   const router = useRouter()
 
@@ -13,10 +18,18 @@ export default function ProfileSettings() {
     const userId = localStorage.getItem('userId') || ''
     if (!userId) return
     fetch(getUserUrl(userId), { cache: 'no-store' })
-      .then((res) => res.ok ? res.json() : null)
+      .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
-        if (data && data.profile && data.profile.bio) {
-          setBio(data.profile.bio)
+        if (data && data.profile) {
+          const prof = data.profile
+          if (prof.bio) setBio(prof.bio)
+          if (prof.profile_image) setProfileImage(prof.profile_image)
+          if (prof.activity) setActivity(prof.activity)
+          if (prof.sns_links) {
+            setYoutube(prof.sns_links.youtube || '')
+            setTwitter(prof.sns_links.twitter || '')
+          }
+          if (prof.visibility) setVisibility(prof.visibility)
         }
       })
   }, [])
@@ -29,7 +42,17 @@ export default function ProfileSettings() {
       return
     }
     try {
-      const res = await axios.put(`/api/users/${userId}/profile`, { bio })
+      const sns: Record<string, string> = {}
+      if (youtube) sns.youtube = youtube
+      if (twitter) sns.twitter = twitter
+      const payload: Record<string, unknown> = {}
+      if (bio) payload.bio = bio
+      if (profileImage) payload.profile_image = profileImage
+      if (activity) payload.activity = activity
+      if (Object.keys(sns).length) payload.sns_links = sns
+      if (visibility) payload.visibility = visibility
+
+      const res = await axios.put(`/api/users/${userId}/profile`, payload)
       setMessage(res.data.message)
       router.refresh()
     } catch (err: unknown) {
@@ -46,12 +69,48 @@ export default function ProfileSettings() {
     <div className="max-w-md mx-auto mt-10">
       <h1 className="text-2xl font-bold mb-4">プロフィール編集</h1>
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <input
+          className="border p-2"
+          type="text"
+          placeholder="プロフィール画像URL"
+          value={profileImage}
+          onChange={(e) => setProfileImage(e.target.value)}
+        />
         <textarea
           className="border p-2"
           placeholder="自己紹介"
           value={bio}
           onChange={(e) => setBio(e.target.value)}
         />
+        <textarea
+          className="border p-2"
+          placeholder="活動内容"
+          value={activity}
+          onChange={(e) => setActivity(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          type="text"
+          placeholder="YouTubeリンク"
+          value={youtube}
+          onChange={(e) => setYoutube(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          type="text"
+          placeholder="Twitterリンク"
+          value={twitter}
+          onChange={(e) => setTwitter(e.target.value)}
+        />
+        <select
+          className="border p-2"
+          value={visibility}
+          onChange={(e) => setVisibility(e.target.value)}
+        >
+          <option value="public">全体公開</option>
+          <option value="followers">フォロワー限定</option>
+          <option value="private">非公開</option>
+        </select>
         <button className="bg-blue-500 text-white py-2" type="submit">
           保存
         </button>


### PR DESCRIPTION
## Summary
- プロフィール編集ページで画像URLや活動内容、SNSリンク、公開範囲を編集できるよう拡張
- プロフィール表示ページにSNSリンクと公開範囲を追加

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68808e74c978832d80ccec9c82242b3d