### PR TITLE
Implement collab profile support

### DIFF
--- a/osarebito-backend/app/main.py
+++ b/osarebito-backend/app/main.py
@@ -37,7 +37,7 @@ def register(user: User):
     users = load_users()
     if any(u["user_id"] == user.user_id for u in users):
         raise HTTPException(status_code=400, detail="User ID already exists")
-    users.append({**user.dict(), "profile": {}})
+    users.append({**user.dict(), "profile": {}, "collab_profile": {}})
     save_users(users)
     return {"message": "registered"}
 
@@ -69,6 +69,20 @@ class ProfileUpdate(BaseModel):
     bio: str | None = None
     activity: str | None = None
     sns_links: dict | None = None
+    visibility: str | None = None
+
+
+class CollabProfile(BaseModel):
+    interests: str | None = None
+    looking_for: str | None = None
+    availability: str | None = None
+    visibility: str = "private"
+
+
+class CollabProfileUpdate(BaseModel):
+    interests: str | None = None
+    looking_for: str | None = None
+    availability: str | None = None
     visibility: str | None = None
 
 
@@ -104,6 +118,29 @@ def update_profile(user_id: str, profile: ProfileUpdate):
             data = profile.dict(exclude_unset=True)
             prof.update({k: v for k, v in data.items() if v is not None})
             u["profile"] = prof
+            save_users(users)
+            return {"message": "updated"}
+    raise HTTPException(status_code=404, detail="User not found")
+
+
+@app.get("/users/{user_id}/collab_profile")
+def get_collab_profile(user_id: str):
+    users = load_users()
+    for u in users:
+        if u["user_id"] == user_id:
+            return u.get("collab_profile", {})
+    raise HTTPException(status_code=404, detail="User not found")
+
+
+@app.put("/users/{user_id}/collab_profile")
+def update_collab_profile(user_id: str, profile: CollabProfileUpdate):
+    users = load_users()
+    for u in users:
+        if u["user_id"] == user_id:
+            prof = u.get("collab_profile", {})
+            data = profile.dict(exclude_unset=True)
+            prof.update({k: v for k, v in data.items() if v is not None})
+            u["collab_profile"] = prof
             save_users(users)
             return {"message": "updated"}
     raise HTTPException(status_code=404, detail="User not found")

--- a/osarebito-frontend/src/app/api/users/[userId]/collab_profile/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/collab_profile/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { updateCollabProfileUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function PUT(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
+    const res = await fetch(updateCollabProfileUrl(userId), {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/page.tsx
+++ b/osarebito-frontend/src/app/page.tsx
@@ -61,6 +61,11 @@ export default function Home() {
               プロフィール設定
             </Link>
           </div>
+          <div className="mt-2">
+            <Link href="/profile/collab-settings" className="text-blue-500 underline">
+              コラボ用プロフィール設定
+            </Link>
+          </div>
         </>
       )}
     </div>

--- a/osarebito-frontend/src/app/profile/[userId]/collab/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/collab/page.tsx
@@ -1,0 +1,31 @@
+import { getCollabProfileUrl } from '../../../../routs'
+
+async function getCollabProfile(userId: string) {
+  const res = await fetch(getCollabProfileUrl(userId), { cache: 'no-store' })
+  if (!res.ok) {
+    return null
+  }
+  return res.json()
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default async function CollabProfile({ params }: any) {
+  const profile = await getCollabProfile(params.userId)
+  if (!profile || Object.keys(profile).length === 0) {
+    return <div className="max-w-md mx-auto mt-10">コラボ用プロフィールがありません</div>
+  }
+  return (
+    <div className="max-w-md mx-auto mt-10 flex flex-col gap-2">
+      <h1 className="text-2xl font-bold mb-4">コラボ用プロフィール</h1>
+      {profile.interests && <p className="mt-2">趣味・嗜好: {profile.interests}</p>}
+      {profile.looking_for && (
+        <p className="mt-2">募集内容: {profile.looking_for}</p>
+      )}
+      {profile.availability && (
+        <p className="mt-2">可能な日時: {profile.availability}</p>
+      )}
+      {profile.visibility && (
+        <p className="mt-2 text-sm text-gray-600">公開範囲: {profile.visibility}</p>
+      )}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/profile/[userId]/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/page.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import Link from 'next/link'
 import { getUserUrl } from '../../../routs'
 
 async function getUser(userId: string) {
@@ -42,6 +43,11 @@ export default async function Profile({ params }: any) {
       {profile.visibility && (
         <p className="mt-2 text-sm text-gray-600">公開範囲: {profile.visibility}</p>
       )}
+      <div className="mt-2">
+        <Link href={`/profile/${params.userId}/collab`} className="text-blue-500 underline">
+          コラボ用プロフィールを見る
+        </Link>
+      </div>
     </div>
   )
 }

--- a/osarebito-frontend/src/app/profile/collab-settings/page.tsx
+++ b/osarebito-frontend/src/app/profile/collab-settings/page.tsx
@@ -1,0 +1,94 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import { getCollabProfileUrl } from '../../../routs'
+import { useRouter } from 'next/navigation'
+
+export default function CollabProfileSettings() {
+  const [interests, setInterests] = useState('')
+  const [lookingFor, setLookingFor] = useState('')
+  const [availability, setAvailability] = useState('')
+  const [visibility, setVisibility] = useState('private')
+  const [message, setMessage] = useState('')
+  const router = useRouter()
+
+  useEffect(() => {
+    const userId = localStorage.getItem('userId') || ''
+    if (!userId) return
+    fetch(getCollabProfileUrl(userId), { cache: 'no-store' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) {
+          if (data.interests) setInterests(data.interests)
+          if (data.looking_for) setLookingFor(data.looking_for)
+          if (data.availability) setAvailability(data.availability)
+          if (data.visibility) setVisibility(data.visibility)
+        }
+      })
+  }, [])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const userId = localStorage.getItem('userId') || ''
+    if (!userId) {
+      setMessage('ログインしてください')
+      return
+    }
+    try {
+      const payload: Record<string, unknown> = {}
+      if (interests) payload.interests = interests
+      if (lookingFor) payload.looking_for = lookingFor
+      if (availability) payload.availability = availability
+      if (visibility) payload.visibility = visibility
+      const res = await axios.put(`/api/users/${userId}/collab_profile`, payload)
+      setMessage(res.data.message)
+      router.refresh()
+    } catch (err: unknown) {
+      if (err && typeof err === 'object' && 'response' in err) {
+        const anyErr = err as { response?: { data?: { detail?: string } } }
+        setMessage(anyErr.response?.data?.detail || 'Error')
+      } else {
+        setMessage('Error')
+      }
+    }
+  }
+
+  return (
+    <div className="max-w-md mx-auto mt-10">
+      <h1 className="text-2xl font-bold mb-4">コラボ用プロフィール編集</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <textarea
+          className="border p-2"
+          placeholder="趣味・嗜好"
+          value={interests}
+          onChange={(e) => setInterests(e.target.value)}
+        />
+        <textarea
+          className="border p-2"
+          placeholder="募集内容"
+          value={lookingFor}
+          onChange={(e) => setLookingFor(e.target.value)}
+        />
+        <input
+          className="border p-2"
+          type="text"
+          placeholder="可能な日時"
+          value={availability}
+          onChange={(e) => setAvailability(e.target.value)}
+        />
+        <select
+          className="border p-2"
+          value={visibility}
+          onChange={(e) => setVisibility(e.target.value)}
+        >
+          <option value="private">非公開</option>
+          <option value="public">公開</option>
+        </select>
+        <button className="bg-blue-500 text-white py-2" type="submit">
+          保存
+        </button>
+      </form>
+      {message && <p className="mt-4">{message}</p>}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/routs.ts
+++ b/osarebito-frontend/src/routs.ts
@@ -2,3 +2,5 @@ export const BACKEND_URL = 'http://localhost:8000'
 export const getUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}`
 export const updateProfileUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/profile`
 export const searchUsersUrl = (query: string) => `${BACKEND_URL}/users/search?query=${encodeURIComponent(query)}`
+export const getCollabProfileUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/collab_profile`
+export const updateCollabProfileUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/collab_profile`


### PR DESCRIPTION
## Summary
- backend: store and update `collab_profile`
- frontend: add collab profile editing/view pages
- add helper URLs and links to new pages

## Testing
- `npm run lint`
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_688092fe10f0832da26d98db2c3a45c1