### PR TITLE
明るくポップな配色へ変更

### DIFF
--- a/osarebito-frontend/src/app/globals.css
+++ b/osarebito-frontend/src/app/globals.css
@@ -1,8 +1,9 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #fff8f0;
+  --foreground: #111111;
+  --accent: #ec4899;
 }
 
 @theme inline {
@@ -14,8 +15,8 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #f5f5f5;
+    --foreground: #111111;
   }
 }
 

--- a/osarebito-frontend/src/app/imagetool/page.tsx
+++ b/osarebito-frontend/src/app/imagetool/page.tsx
@@ -102,7 +102,7 @@ export default function ImageTool() {
         AI対策
       </label>
       <button
-        className="bg-blue-500 text-white py-2 px-4 rounded-md shadow-md hover:bg-blue-600 transition-colors duration-200"
+        className="bg-pink-500 text-white py-2 px-4 rounded-md shadow-md hover:bg-pink-600 transition-colors duration-200"
         onClick={handleProcess}
         disabled={!file}
       >
@@ -121,7 +121,7 @@ export default function ImageTool() {
           <a
             href={resultUrl}
             download="processed.jpg"
-            className="text-blue-500 underline text-center hover:text-blue-700 transition-colors duration-200"
+            className="text-pink-500 underline text-center hover:text-pink-700 transition-colors duration-200"
           >
             Download
           </a>

--- a/osarebito-frontend/src/app/login/page.tsx
+++ b/osarebito-frontend/src/app/login/page.tsx
@@ -53,13 +53,13 @@ export default function Login() {
           onChange={(e) => setPassword(e.target.value)}
           required
         />
-        <button className="bg-blue-500 text-white py-2" type="submit">
+        <button className="bg-pink-500 text-white py-2" type="submit">
           Login
         </button>
       </form>
       {message && <p className="mt-4">{message}</p>}
       <div className="mt-4">
-        <Link href="/signup" className="text-blue-500 underline">
+        <Link href="/signup" className="text-pink-500 underline">
           Go to Sign Up
         </Link>
       </div>

--- a/osarebito-frontend/src/app/page.tsx
+++ b/osarebito-frontend/src/app/page.tsx
@@ -25,7 +25,7 @@ export default function Home() {
         <div>
           <p>You are logged in.</p>
           <button
-            className="bg-blue-500 text-white py-2 px-4 mt-4"
+            className="bg-pink-500 text-white py-2 px-4 mt-4"
             onClick={handleLogout}
           >
             Logout
@@ -34,35 +34,35 @@ export default function Home() {
       ) : (
         <div>
           <p>You are not logged in.</p>
-          <Link href="/login" className="text-blue-500 underline">
+          <Link href="/login" className="text-pink-500 underline">
             Login
           </Link>
         </div>
       )}
       <div className="mt-4">
-        <Link href="/imagetool" className="text-blue-500 underline">
+        <Link href="/imagetool" className="text-pink-500 underline">
           画像圧縮ツール
         </Link>
       </div>
       <div className="mt-2">
-        <Link href="/profile/search" className="text-blue-500 underline">
+        <Link href="/profile/search" className="text-pink-500 underline">
           ユーザー検索
         </Link>
       </div>
       {loggedIn && (
         <>
           <div className="mt-2">
-            <Link href={`/profile/${userId}`} className="text-blue-500 underline">
+            <Link href={`/profile/${userId}`} className="text-pink-500 underline">
               プロフィール
             </Link>
           </div>
           <div className="mt-2">
-            <Link href="/profile/settings" className="text-blue-500 underline">
+            <Link href="/profile/settings" className="text-pink-500 underline">
               プロフィール設定
             </Link>
           </div>
           <div className="mt-2">
-            <Link href="/profile/collab-settings" className="text-blue-500 underline">
+            <Link href="/profile/collab-settings" className="text-pink-500 underline">
               コラボ用プロフィール設定
             </Link>
           </div>

--- a/osarebito-frontend/src/app/profile/[userId]/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/page.tsx
@@ -29,12 +29,12 @@ export default async function Profile({ params }: any) {
       {profile.sns_links && (
         <div className="mt-2 flex flex-col gap-1">
           {profile.sns_links.youtube && (
-            <a href={profile.sns_links.youtube} className="text-blue-500 underline">
+            <a href={profile.sns_links.youtube} className="text-pink-500 underline">
               YouTube
             </a>
           )}
           {profile.sns_links.twitter && (
-            <a href={profile.sns_links.twitter} className="text-blue-500 underline">
+            <a href={profile.sns_links.twitter} className="text-pink-500 underline">
               Twitter
             </a>
           )}
@@ -44,7 +44,7 @@ export default async function Profile({ params }: any) {
         <p className="mt-2 text-sm text-gray-600">公開範囲: {profile.visibility}</p>
       )}
       <div className="mt-2">
-        <Link href={`/profile/${params.userId}/collab`} className="text-blue-500 underline">
+        <Link href={`/profile/${params.userId}/collab`} className="text-pink-500 underline">
           コラボ用プロフィールを見る
         </Link>
       </div>

--- a/osarebito-frontend/src/app/profile/collab-settings/page.tsx
+++ b/osarebito-frontend/src/app/profile/collab-settings/page.tsx
@@ -84,7 +84,7 @@ export default function CollabProfileSettings() {
           <option value="private">非公開</option>
           <option value="public">公開</option>
         </select>
-        <button className="bg-blue-500 text-white py-2" type="submit">
+        <button className="bg-pink-500 text-white py-2" type="submit">
           保存
         </button>
       </form>

--- a/osarebito-frontend/src/app/profile/search/page.tsx
+++ b/osarebito-frontend/src/app/profile/search/page.tsx
@@ -41,7 +41,7 @@ export default function ProfileSearch() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />
-        <button className="bg-blue-500 text-white px-4" onClick={handleSearch}>
+        <button className="bg-pink-500 text-white px-4" onClick={handleSearch}>
           検索
         </button>
       </div>
@@ -50,7 +50,7 @@ export default function ProfileSearch() {
         <ul className="list-disc pl-5">
           {results.map((u) => (
             <li key={u.user_id} className="mt-2">
-              <Link href={`/profile/${u.user_id}`} className="text-blue-500 underline">
+              <Link href={`/profile/${u.user_id}`} className="text-pink-500 underline">
                 {u.username}
               </Link>
             </li>

--- a/osarebito-frontend/src/app/profile/settings/page.tsx
+++ b/osarebito-frontend/src/app/profile/settings/page.tsx
@@ -111,7 +111,7 @@ export default function ProfileSettings() {
           <option value="followers">フォロワー限定</option>
           <option value="private">非公開</option>
         </select>
-        <button className="bg-blue-500 text-white py-2" type="submit">
+        <button className="bg-pink-500 text-white py-2" type="submit">
           保存
         </button>
       </form>

--- a/osarebito-frontend/src/app/signup/page.tsx
+++ b/osarebito-frontend/src/app/signup/page.tsx
@@ -99,20 +99,20 @@ export default function SignUp() {
           ].map((r) => (
             <div
               key={r.key}
-              className={`flex-1 border p-4 cursor-pointer rounded ${role === r.key ? 'bg-blue-100 border-blue-500' : ''}`}
+              className={`flex-1 border p-4 cursor-pointer rounded ${role === r.key ? 'bg-pink-100 border-pink-500' : ''}`}
               onClick={() => setRole(r.key)}
             >
               {r.label}
             </div>
           ))}
         </div>
-        <button className="bg-blue-500 text-white py-2" type="submit">
+        <button className="bg-pink-500 text-white py-2" type="submit">
           Register
         </button>
       </form>
       {message && <p className="mt-4">{message}</p>}
       <div className="mt-4">
-        <Link href="/login" className="text-blue-500 underline">
+        <Link href="/login" className="text-pink-500 underline">
           Go to Login
         </Link>
       </div>


### PR DESCRIPTION
## Summary
- 既存のダーク寄りの配色を改善し、全体的に明るくポップな印象へ
- グローバルスタイルを調整し、背景色を淡い色に変更
- ボタンやリンクのアクセントカラーをピンク系に統一

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688094baef58832da4c577762fd419c8