### PR TITLE
Add profile links on top page

### DIFF
--- a/osarebito-frontend/src/app/page.tsx
+++ b/osarebito-frontend/src/app/page.tsx
@@ -58,7 +58,15 @@ export default function Home() {
           </div>
           <div className="mt-2">
             <Link href="/profile/settings" className="text-pink-500 underline">
-              プロフィール設定
+              プロフィール編集
+            </Link>
+          </div>
+          <div className="mt-2">
+            <Link
+              href={`/profile/${userId}/collab`}
+              className="text-pink-500 underline"
+            >
+              コラボプロフィール
             </Link>
           </div>
           <div className="mt-2">


### PR DESCRIPTION
## Summary
- adjust link text to プロフィール編集
- add コラボプロフィール link on top page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880964cf388832da886a83ec2ba71c3