### PR TITLE
Add sidebar navigation

### DIFF
--- a/osarebito-frontend/package-lock.json
+++ b/osarebito-frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "osarebito",
       "version": "0.1.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "axios": "^1.6.8",
         "next": "15.4.2",
         "react": "19.1.0",
@@ -224,6 +225,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/osarebito-frontend/package.json
+++ b/osarebito-frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "axios": "^1.6.8",
     "next": "15.4.2",
     "react": "19.1.0",

--- a/osarebito-frontend/src/app/layout.tsx
+++ b/osarebito-frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Sidebar from "@/components/Sidebar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,10 +25,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <div className="flex">
+          <Sidebar />
+          <main className="flex-1 p-4">{children}</main>
+        </div>
       </body>
     </html>
   );

--- a/osarebito-frontend/src/components/Sidebar.tsx
+++ b/osarebito-frontend/src/components/Sidebar.tsx
@@ -1,0 +1,36 @@
+'use client'
+import Link from 'next/link'
+import {
+  HomeIcon,
+  ArrowRightOnRectangleIcon,
+  UserPlusIcon,
+  PhotoIcon,
+  MagnifyingGlassIcon,
+} from '@heroicons/react/24/outline'
+
+export default function Sidebar() {
+  return (
+    <nav className="w-48 bg-pink-50 min-h-screen p-4 space-y-4">
+      <Link href="/" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <HomeIcon className="w-5 h-5" />
+        <span>ホーム</span>
+      </Link>
+      <Link href="/login" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <ArrowRightOnRectangleIcon className="w-5 h-5" />
+        <span>ログイン</span>
+      </Link>
+      <Link href="/signup" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <UserPlusIcon className="w-5 h-5" />
+        <span>新規登録</span>
+      </Link>
+      <Link href="/imagetool" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <PhotoIcon className="w-5 h-5" />
+        <span>画像圧縮</span>
+      </Link>
+      <Link href="/profile/search" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <MagnifyingGlassIcon className="w-5 h-5" />
+        <span>ユーザー検索</span>
+      </Link>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- add `@heroicons/react` for icons
- add sidebar navigation with icons
- show sidebar in layout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68809fb12d90832d9a406d44d0dd172f