### PR TITLE
Implement follow system

### DIFF
--- a/osarebito-frontend/src/app/api/users/[userId]/follow/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/follow/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { followUserUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function POST(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
+    const res = await fetch(followUserUrl(userId), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/users/[userId]/followers/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/followers/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { followersUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function GET(req: NextRequest, { params }: { params: any }) {
+  try {
+    const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
+    const res = await fetch(followersUrl(userId))
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/users/[userId]/following/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/following/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { followingUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function GET(req: NextRequest, { params }: { params: any }) {
+  try {
+    const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
+    const res = await fetch(followingUrl(userId))
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/users/[userId]/unfollow/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/unfollow/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { unfollowUserUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function POST(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
+    const res = await fetch(unfollowUserUrl(userId), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/profile/[userId]/followers/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/followers/page.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link'
+import { followersUrl } from '../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+async function getFollowers(userId: string) {
+  const res = await fetch(followersUrl(userId), { cache: 'no-store' })
+  if (!res.ok) return []
+  return res.json()
+}
+
+export default async function FollowersPage({ params }: any) {
+  const followers = await getFollowers(params.userId)
+  return (
+    <div className="max-w-md mx-auto mt-10">
+      <h1 className="text-2xl font-bold mb-4">フォロワー</h1>
+      {followers.length === 0 ? (
+        <p>フォロワーはいません</p>
+      ) : (
+        <ul className="list-disc pl-5">
+          {followers.map((u: any) => (
+            <li key={u.user_id} className="mt-2">
+              <Link href={`/profile/${u.user_id}`} className="text-pink-500 underline">
+                {u.username}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/profile/[userId]/following/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/following/page.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link'
+import { followingUrl } from '../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+async function getFollowing(userId: string) {
+  const res = await fetch(followingUrl(userId), { cache: 'no-store' })
+  if (!res.ok) return []
+  return res.json()
+}
+
+export default async function FollowingPage({ params }: any) {
+  const following = await getFollowing(params.userId)
+  return (
+    <div className="max-w-md mx-auto mt-10">
+      <h1 className="text-2xl font-bold mb-4">フォロー中</h1>
+      {following.length === 0 ? (
+        <p>フォローしているユーザーはいません</p>
+      ) : (
+        <ul className="list-disc pl-5">
+          {following.map((u: any) => (
+            <li key={u.user_id} className="mt-2">
+              <Link href={`/profile/${u.user_id}`} className="text-pink-500 underline">
+                {u.username}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/profile/[userId]/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { getUserUrl } from '../../../routs'
+import FollowButton from '../../../components/FollowButton'
 
 async function getUser(userId: string) {
   const res = await fetch(getUserUrl(userId), { cache: 'no-store' })
@@ -16,11 +17,22 @@ export default async function Profile({ params }: any) {
     return <div className="max-w-md mx-auto mt-10">ユーザーが見つかりません</div>
   }
   const profile = user.profile || {}
+  const followerCount = Array.isArray(user.followers) ? user.followers.length : 0
+  const followingCount = Array.isArray(user.following) ? user.following.length : 0
   return (
     <div className="max-w-md mx-auto mt-10 flex flex-col gap-2">
       <h1 className="text-2xl font-bold mb-4">プロフィール</h1>
       <p>User ID: {user.user_id}</p>
       <p>Username: {user.username}</p>
+      <div className="flex gap-4 mt-1">
+        <Link href={`/profile/${params.userId}/followers`} className="underline">
+          フォロワー {followerCount}
+        </Link>
+        <Link href={`/profile/${params.userId}/following`} className="underline">
+          フォロー {followingCount}
+        </Link>
+        <FollowButton targetId={params.userId} followers={user.followers || []} />
+      </div>
       {profile.profile_image && (
         <Image src={profile.profile_image} alt="profile" width={200} height={200} className="mt-2" />
       )}

--- a/osarebito-frontend/src/components/FollowButton.tsx
+++ b/osarebito-frontend/src/components/FollowButton.tsx
@@ -1,0 +1,47 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import axios from 'axios'
+
+interface Props {
+  targetId: string
+  followers: string[]
+}
+
+export default function FollowButton({ targetId, followers }: Props) {
+  const [ready, setReady] = useState(false)
+  const [following, setFollowing] = useState(false)
+  const router = useRouter()
+
+  useEffect(() => {
+    const myId = localStorage.getItem('userId') || ''
+    if (myId) {
+      setFollowing(followers.includes(myId))
+    }
+    setReady(true)
+  }, [followers])
+
+  const handleClick = async () => {
+    const myId = localStorage.getItem('userId') || ''
+    if (!myId || myId === targetId) return
+    try {
+      const payload = { follower_id: myId }
+      if (following) {
+        await axios.post(`/api/users/${targetId}/unfollow`, payload)
+      } else {
+        await axios.post(`/api/users/${targetId}/follow`, payload)
+      }
+      setFollowing(!following)
+      router.refresh()
+    } catch {
+      // ignore
+    }
+  }
+
+  if (!ready) return null
+  return (
+    <button className="bg-pink-500 text-white px-4 py-1" onClick={handleClick}>
+      {following ? 'フォロー中' : 'フォローする'}
+    </button>
+  )
+}

--- a/osarebito-frontend/src/routs.ts
+++ b/osarebito-frontend/src/routs.ts
@@ -4,3 +4,7 @@ export const updateProfileUrl = (userId: string) => `${BACKEND_URL}/users/${user
 export const searchUsersUrl = (query: string) => `${BACKEND_URL}/users/search?query=${encodeURIComponent(query)}`
 export const getCollabProfileUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/collab_profile`
 export const updateCollabProfileUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/collab_profile`
+export const followUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/follow`
+export const unfollowUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/unfollow`
+export const followersUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/followers`
+export const followingUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/following`


### PR DESCRIPTION
## Summary
- プロフィール登録時にフォロワー・フォロー情報を初期化
- フォロー／アンフォロー API を追加
- フォロワー一覧・フォロー一覧 API を追加
- Next.js から新 API を呼び出すエンドポイントを実装
- フォロー用コンポーネント `FollowButton` を作成
- プロフィール画面にフォロー数表示とフォローボタンを追加
- フォロワー一覧・フォロー一覧ページを新規追加

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6880a34a2d00832dba0e1cce53658615