### PR TITLE
Fix login error by adding missing dependency

### DIFF
--- a/osarebito-backend/requirements.txt
+++ b/osarebito-backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 python-dotenv
+email-validator


### PR DESCRIPTION
## Summary
- add the `email-validator` package to backend requirements so FastAPI can validate `EmailStr`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880d3a46108832d9fae4c95dcdbcd12