### PR TITLE
Fix backend startup on Windows

### DIFF
--- a/run.py
+++ b/run.py
@@ -2,11 +2,14 @@ import argparse
 import subprocess
 from pathlib import Path
 import sys
+import os
 
 ROOT = Path(__file__).resolve().parent
 FRONTEND_DIR = ROOT / "osarebito-frontend"
 BACKEND_DIR = ROOT / "osarebito-backend"
-BACKEND_UVICORN = BACKEND_DIR / "venv" / "bin" / "uvicorn"
+VENV_BIN = BACKEND_DIR / "venv" / ("Scripts" if os.name == "nt" else "bin")
+BACKEND_PYTHON = VENV_BIN / ("python.exe" if os.name == "nt" else "python")
+BACKEND_UVICORN = VENV_BIN / ("uvicorn.exe" if os.name == "nt" else "uvicorn")
 
 
 def run_frontend():
@@ -14,7 +17,9 @@ def run_frontend():
 
 
 def run_backend():
-    if BACKEND_UVICORN.exists():
+    if BACKEND_PYTHON.exists():
+        cmd = [str(BACKEND_PYTHON), "-m", "uvicorn", "app.main:app", "--reload"]
+    elif BACKEND_UVICORN.exists():
         cmd = [str(BACKEND_UVICORN), "app.main:app", "--reload"]
     else:
         cmd = [sys.executable, "-m", "uvicorn", "app.main:app", "--reload"]
@@ -23,7 +28,9 @@ def run_backend():
 
 def run_both():
     front_proc = subprocess.Popen(["npm", "run", "dev"], cwd=FRONTEND_DIR)
-    if BACKEND_UVICORN.exists():
+    if BACKEND_PYTHON.exists():
+        back_cmd = [str(BACKEND_PYTHON), "-m", "uvicorn", "app.main:app", "--reload"]
+    elif BACKEND_UVICORN.exists():
         back_cmd = [str(BACKEND_UVICORN), "app.main:app", "--reload"]
     else:
         back_cmd = [sys.executable, "-m", "uvicorn", "app.main:app", "--reload"]

--- a/run_backend.py
+++ b/run_backend.py
@@ -1,15 +1,20 @@
 import subprocess
 from pathlib import Path
 import sys
+import os
 
 ROOT = Path(__file__).resolve().parent
 BACKEND_DIR = ROOT / "osarebito-backend"
-BACKEND_UVICORN = BACKEND_DIR / "venv" / "bin" / "uvicorn"
+VENV_BIN = BACKEND_DIR / "venv" / ("Scripts" if os.name == "nt" else "bin")
+BACKEND_PYTHON = VENV_BIN / ("python.exe" if os.name == "nt" else "python")
+BACKEND_UVICORN = VENV_BIN / ("uvicorn.exe" if os.name == "nt" else "uvicorn")
 
 
 def main() -> None:
     """Start the FastAPI backend with Uvicorn."""
-    if BACKEND_UVICORN.exists():
+    if BACKEND_PYTHON.exists():
+        cmd = [str(BACKEND_PYTHON), "-m", "uvicorn", "app.main:app", "--reload"]
+    elif BACKEND_UVICORN.exists():
         cmd = [str(BACKEND_UVICORN), "app.main:app", "--reload"]
     else:
         cmd = [sys.executable, "-m", "uvicorn", "app.main:app", "--reload"]


### PR DESCRIPTION
## Summary
- use venv python if available when launching backend
- support Windows path layout in launcher scripts

## Testing
- `python run_backend.py & sleep 3; kill $!`
- `python run.py backend & sleep 3; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_6880dd089ccc832d97f8c613bfb82e74