### PR TITLE
Fix frontend startup

### DIFF
--- a/run_frontend.bat
+++ b/run_frontend.bat
@@ -1,4 +1,8 @@
 @echo off
 set SCRIPT_DIR=%~dp0
 cd /d "%SCRIPT_DIR%osarebito-frontend"
+if not exist node_modules (
+  echo Installing dependencies...
+  npm install || exit /b 1
+)
 npm run dev

--- a/run_frontend.py
+++ b/run_frontend.py
@@ -16,6 +16,11 @@ def main() -> None:
         sys.stderr.write("npm was not found. Please install Node.js and ensure npm is available in PATH.\n")
         sys.exit(1)
 
+    # Install dependencies if node_modules is missing
+    node_modules = FRONTEND_DIR / "node_modules"
+    if not node_modules.exists():
+        subprocess.run([npm, "install"], cwd=FRONTEND_DIR, check=True)
+
     subprocess.run([npm, "run", "dev"], cwd=FRONTEND_DIR)
 
 


### PR DESCRIPTION
## Summary
- ensure `run_frontend` scripts install dependencies if needed

## Testing
- `python run_frontend.py > /tmp/frontend.log & sleep 3; pkill -f next; cat /tmp/frontend.log`
- `python run_backend.py > /tmp/backend.log & sleep 3; pkill -f uvicorn; cat /tmp/backend.log`


------
https://chatgpt.com/codex/tasks/task_e_6880e27892d0832dad6de415eb7d7f37