### PR TITLE
Fix startup scripts

### DIFF
--- a/run_backend.py
+++ b/run_backend.py
@@ -12,12 +12,17 @@ BACKEND_UVICORN = VENV_BIN / ("uvicorn.exe" if os.name == "nt" else "uvicorn")
 
 def main() -> None:
     """Start the FastAPI backend with Uvicorn."""
+    host = os.environ.get("BACKEND_HOST", "127.0.0.1")
+    port = os.environ.get("BACKEND_PORT", "8000")
+
     if BACKEND_PYTHON.exists():
         cmd = [str(BACKEND_PYTHON), "-m", "uvicorn", "app.main:app", "--reload"]
     elif BACKEND_UVICORN.exists():
         cmd = [str(BACKEND_UVICORN), "app.main:app", "--reload"]
     else:
         cmd = [sys.executable, "-m", "uvicorn", "app.main:app", "--reload"]
+
+    cmd += ["--host", host, "--port", port]
     subprocess.run(cmd, cwd=BACKEND_DIR)
 
 

--- a/run_frontend.py
+++ b/run_frontend.py
@@ -21,7 +21,9 @@ def main() -> None:
     if not node_modules.exists():
         subprocess.run([npm, "install"], cwd=FRONTEND_DIR, check=True)
 
-    subprocess.run([npm, "run", "dev"], cwd=FRONTEND_DIR)
+    env = os.environ.copy()
+    env.setdefault("PORT", os.environ.get("FRONTEND_PORT", "3000"))
+    subprocess.run([npm, "run", "dev"], cwd=FRONTEND_DIR, env=env)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- set host and port environment values for backend
- allow frontend port override

## Testing
- `python -m py_compile run_backend.py run_frontend.py`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6880e7966a84832d813a79383f11f6fe