### PR TITLE
Fix profile settings fetch

### DIFF
--- a/osarebito-frontend/src/app/api/users/[userId]/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getUserUrl } from '../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function GET(req: NextRequest, { params }: { params: any }) {
+  try {
+    const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
+    const res = await fetch(getUserUrl(userId))
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/profile/settings/page.tsx
+++ b/osarebito-frontend/src/app/profile/settings/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
 import axios from 'axios'
-import { getUserUrl } from '../../../routs'
 import { useRouter } from 'next/navigation'
 
 export default function ProfileSettings() {
@@ -17,7 +16,7 @@ export default function ProfileSettings() {
   useEffect(() => {
     const userId = localStorage.getItem('userId') || ''
     if (!userId) return
-    fetch(getUserUrl(userId), { cache: 'no-store' })
+    fetch(`/api/users/${userId}`, { cache: 'no-store' })
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (data && data.profile) {


### PR DESCRIPTION
## Summary
- add API route to proxy GET /users/:userId to backend
- fetch profile via the new API route

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880fc149310832db122d8567c2fe218