### PR TITLE
Add interest and mutual follower features

### DIFF
--- a/osarebito-frontend/src/app/api/users/[userId]/interest/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/interest/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { interestUserUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function POST(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
+    const res = await fetch(interestUserUrl(userId), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/users/[userId]/mutual_followers/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/mutual_followers/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { mutualFollowersUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function GET(req: NextRequest, { params }: { params: any }) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const myId = searchParams.get('my_id') || ''
+    const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
+    const res = await fetch(mutualFollowersUrl(userId, myId))
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/users/[userId]/uninterest/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/uninterest/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { uninterestUserUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function POST(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
+    const res = await fetch(uninterestUserUrl(userId), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/profile/[userId]/mutual/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/mutual/page.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link'
+import { mutualFollowersUrl } from '../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+async function getMutualFollowers(userId: string, myId: string) {
+  const res = await fetch(mutualFollowersUrl(userId, myId), { cache: 'no-store' })
+  if (!res.ok) return []
+  return res.json()
+}
+
+export default async function MutualFollowers({ params, searchParams }: any) {
+  const myId = searchParams?.my_id || ''
+  const users = await getMutualFollowers(params.userId, myId)
+  return (
+    <div className="max-w-md mx-auto mt-10">
+      <h1 className="text-2xl font-bold mb-4">知り合いのフォロワー</h1>
+      {users.length === 0 ? (
+        <p>知り合いのフォロワーはいません</p>
+      ) : (
+        <ul className="list-disc pl-5">
+          {users.map((u: any) => (
+            <li key={u.user_id} className="mt-2">
+              <Link href={`/profile/${u.user_id}`} className="text-pink-500 underline">
+                {u.username}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/profile/[userId]/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/page.tsx
@@ -2,6 +2,8 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { getUserUrl } from '../../../routs'
 import FollowButton from '../../../components/FollowButton'
+import InterestButton from '../../../components/InterestButton'
+import MutualLink from '../../../components/MutualLink'
 
 async function getUser(userId: string) {
   const res = await fetch(getUserUrl(userId), { cache: 'no-store' })
@@ -19,19 +21,22 @@ export default async function Profile({ params }: any) {
   const profile = user.profile || {}
   const followerCount = Array.isArray(user.followers) ? user.followers.length : 0
   const followingCount = Array.isArray(user.following) ? user.following.length : 0
+  const interested = Array.isArray(user.interested) ? user.interested : []
   return (
     <div className="max-w-md mx-auto mt-10 flex flex-col gap-2">
       <h1 className="text-2xl font-bold mb-4">プロフィール</h1>
       <p>User ID: {user.user_id}</p>
       <p>Username: {user.username}</p>
-      <div className="flex gap-4 mt-1">
+      <div className="flex gap-4 mt-1 flex-wrap">
         <Link href={`/profile/${params.userId}/followers`} className="underline">
           フォロワー {followerCount}
         </Link>
         <Link href={`/profile/${params.userId}/following`} className="underline">
           フォロー {followingCount}
         </Link>
+        <MutualLink targetId={params.userId} />
         <FollowButton targetId={params.userId} followers={user.followers || []} />
+        <InterestButton targetId={params.userId} interested={interested} />
       </div>
       {profile.profile_image && (
         <Image src={profile.profile_image} alt="profile" width={200} height={200} className="mt-2" />

--- a/osarebito-frontend/src/components/InterestButton.tsx
+++ b/osarebito-frontend/src/components/InterestButton.tsx
@@ -1,0 +1,47 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import axios from 'axios'
+
+interface Props {
+  targetId: string
+  interested: string[]
+}
+
+export default function InterestButton({ targetId, interested }: Props) {
+  const [ready, setReady] = useState(false)
+  const [state, setState] = useState(false)
+  const router = useRouter()
+
+  useEffect(() => {
+    const myId = localStorage.getItem('userId') || ''
+    if (myId) {
+      setState(interested.includes(myId))
+    }
+    setReady(true)
+  }, [interested])
+
+  const handleClick = async () => {
+    const myId = localStorage.getItem('userId') || ''
+    if (!myId || myId === targetId) return
+    try {
+      const payload = { user_id: myId }
+      if (state) {
+        await axios.post(`/api/users/${targetId}/uninterest`, payload)
+      } else {
+        await axios.post(`/api/users/${targetId}/interest`, payload)
+      }
+      setState(!state)
+      router.refresh()
+    } catch {
+      // ignore
+    }
+  }
+
+  if (!ready) return null
+  return (
+    <button className="bg-gray-500 text-white px-4 py-1" onClick={handleClick}>
+      {state ? '気になる済み' : '気になる'}
+    </button>
+  )
+}

--- a/osarebito-frontend/src/components/MutualLink.tsx
+++ b/osarebito-frontend/src/components/MutualLink.tsx
@@ -1,0 +1,17 @@
+'use client'
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+
+export default function MutualLink({ targetId }: { targetId: string }) {
+  const [myId, setMyId] = useState('')
+  useEffect(() => {
+    const id = localStorage.getItem('userId') || ''
+    setMyId(id)
+  }, [])
+  if (!myId) return null
+  return (
+    <Link href={`/profile/${targetId}/mutual?my_id=${myId}`} className="underline">
+      知り合いのフォロワー
+    </Link>
+  )
+}

--- a/osarebito-frontend/src/routs.ts
+++ b/osarebito-frontend/src/routs.ts
@@ -6,5 +6,9 @@ export const getCollabProfileUrl = (userId: string) => `${BACKEND_URL}/users/${u
 export const updateCollabProfileUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/collab_profile`
 export const followUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/follow`
 export const unfollowUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/unfollow`
+export const interestUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/interest`
+export const uninterestUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/uninterest`
+export const mutualFollowersUrl = (userId: string, myId: string) =>
+  `${BACKEND_URL}/users/${userId}/mutual_followers?my_id=${myId}`
 export const followersUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/followers`
 export const followingUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/following`


### PR DESCRIPTION
## Summary
- add interested list to user data
- implement interest/uninterest and mutual follower FastAPI endpoints
- support new backend routes on the frontend
- add InterestButton and MutualLink components
- display new buttons and link on the public profile page
- create mutual followers page

## Testing
- `npm run lint`
- `npm run build`
- `python3 -m py_compile osarebito-backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68816f3c9320832d86ac4fa3532dbc92