### PR TITLE
コミュニティ用サイドメニューを追加

### DIFF
--- a/osarebito-frontend/src/app/community/notifications/page.tsx
+++ b/osarebito-frontend/src/app/community/notifications/page.tsx
@@ -1,0 +1,8 @@
+export default function CommunityNotifications() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">通知</h1>
+      <p>通知がここに表示されます。</p>
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/community/page.tsx
+++ b/osarebito-frontend/src/app/community/page.tsx
@@ -1,0 +1,8 @@
+export default function CommunityHome() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">コミュニティタイムライン</h1>
+      <p>ここにタイムラインが表示されます。</p>
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/community/trends/page.tsx
+++ b/osarebito-frontend/src/app/community/trends/page.tsx
@@ -1,0 +1,8 @@
+export default function CommunityTrends() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">トレンド</h1>
+      <p>トレンドの一覧が表示されます。</p>
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/layout.tsx
+++ b/osarebito-frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Sidebar from "@/components/Sidebar";
+import CommunitySidebar from "@/components/CommunitySidebar";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,6 +29,7 @@ export default function RootLayout({
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <div className="flex">
           <Sidebar />
+          <CommunitySidebar />
           <main className="flex-1 p-4">{children}</main>
         </div>
       </body>

--- a/osarebito-frontend/src/components/CommunitySidebar.tsx
+++ b/osarebito-frontend/src/components/CommunitySidebar.tsx
@@ -1,0 +1,27 @@
+'use client'
+import Link from 'next/link'
+import {
+  ChatBubbleLeftRightIcon,
+  HashtagIcon,
+  BellIcon,
+} from '@heroicons/react/24/outline'
+
+export default function CommunitySidebar() {
+  return (
+    <nav className="w-48 bg-pink-100 min-h-screen p-4 space-y-4 border-r border-pink-200">
+      <h2 className="text-lg font-semibold text-pink-700">コミュニティ</h2>
+      <Link href="/community" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <ChatBubbleLeftRightIcon className="w-5 h-5" />
+        <span>タイムライン</span>
+      </Link>
+      <Link href="/community/trends" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <HashtagIcon className="w-5 h-5" />
+        <span>トレンド</span>
+      </Link>
+      <Link href="/community/notifications" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <BellIcon className="w-5 h-5" />
+        <span>通知</span>
+      </Link>
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary
- コミュニティ用サイドメニュー `CommunitySidebar` を新規作成
- ルートレイアウトで `CommunitySidebar` を表示
- コミュニティの各ページ(タイムライン/トレンド/通知)を追加

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68817364a9d0832d8a08caff5e319ada