### PR TITLE
Implement community posting API routes

### DIFF
--- a/osarebito-frontend/src/app/api/posts/[postId]/comments/route.ts
+++ b/osarebito-frontend/src/app/api/posts/[postId]/comments/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { postCommentsUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function GET(req: NextRequest, { params }: { params: any }) {
+  try {
+    const postId = Array.isArray(params.postId) ? params.postId[0] : params.postId
+    const res = await fetch(postCommentsUrl(Number(postId)))
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}
+
+export async function POST(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const postId = Array.isArray(params.postId) ? params.postId[0] : params.postId
+    const res = await fetch(postCommentsUrl(Number(postId)), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/posts/[postId]/like/route.ts
+++ b/osarebito-frontend/src/app/api/posts/[postId]/like/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { likePostUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function POST(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const postId = Array.isArray(params.postId) ? params.postId[0] : params.postId
+    const res = await fetch(likePostUrl(Number(postId)), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/posts/[postId]/likers/route.ts
+++ b/osarebito-frontend/src/app/api/posts/[postId]/likers/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { postLikersUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function GET(req: NextRequest, { params }: { params: any }) {
+  try {
+    const postId = Array.isArray(params.postId) ? params.postId[0] : params.postId
+    const res = await fetch(postLikersUrl(Number(postId)))
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/posts/[postId]/unlike/route.ts
+++ b/osarebito-frontend/src/app/api/posts/[postId]/unlike/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { unlikePostUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function POST(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const postId = Array.isArray(params.postId) ? params.postId[0] : params.postId
+    const res = await fetch(unlikePostUrl(Number(postId)), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/posts/route.ts
+++ b/osarebito-frontend/src/app/api/posts/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { postsUrl, createPostUrl } from '../../../routs'
+
+export async function GET(req: NextRequest) {
+  try {
+    const { searchParams } = new URL(req.url)
+    const feed = searchParams.get('feed') || 'all'
+    const user_id = searchParams.get('user_id') || undefined
+    const url = postsUrl(feed, user_id || undefined)
+    const res = await fetch(url)
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json()
+    const res = await fetch(createPostUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add Next.js API handlers for community posts
- support likes, unlikes and comments via API routes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68818ee1cf8c832d9c69cee6fc40201f