### PR TITLE
Add real-time updates for community posts

### DIFF
--- a/osarebito-frontend/src/routs.ts
+++ b/osarebito-frontend/src/routs.ts
@@ -24,3 +24,4 @@ export const likePostUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}/l
 export const unlikePostUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}/unlike`
 export const postLikersUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}/likers`
 export const postCommentsUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}/comments`
+export const updatesWsUrl = BACKEND_URL.replace(/^http/, 'ws') + '/ws/updates'


### PR DESCRIPTION
## Summary
- implement WebSocket server in FastAPI
- broadcast new posts and likes to clients
- add WebSocket client in community page
- expose WS URL constant

## Testing
- `python -m py_compile osarebito-backend/app/main.py`
- `osarebito-backend/venv/bin/python -m py_compile osarebito-backend/app/main.py`
- `cd osarebito-frontend && npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68819083e610832d90c3b455b5611f6f