### PR TITLE
コミュニティ機能の拡充

### DIFF
--- a/osarebito-frontend/src/app/api/posts/[postId]/retweet/route.ts
+++ b/osarebito-frontend/src/app/api/posts/[postId]/retweet/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { retweetPostUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function POST(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const postId = Array.isArray(params.postId) ? params.postId[0] : params.postId
+    const res = await fetch(retweetPostUrl(Number(postId)), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/posts/[postId]/unretweet/route.ts
+++ b/osarebito-frontend/src/app/api/posts/[postId]/unretweet/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { unretweetPostUrl } from '../../../../../routs'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function POST(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const postId = Array.isArray(params.postId) ? params.postId[0] : params.postId
+    const res = await fetch(unretweetPostUrl(Number(postId)), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/community/page.tsx
+++ b/osarebito-frontend/src/app/community/page.tsx
@@ -14,6 +14,7 @@ interface Post {
   anonymous?: boolean
   best_answer_id?: number | null
   likes?: string[]
+  retweets?: string[]
 }
 
 interface User {
@@ -56,6 +57,12 @@ export default function CommunityHome() {
           setPosts((p) =>
             p.map((post) =>
               post.id === msg.post_id ? { ...post, likes: msg.likes } : post,
+            ),
+          )
+        } else if (msg.type === 'retweet') {
+          setPosts((p) =>
+            p.map((post) =>
+              post.id === msg.post_id ? { ...post, retweets: msg.retweets } : post,
             ),
           )
         }
@@ -118,6 +125,27 @@ export default function CommunityHome() {
               likes: liked
                 ? (p.likes || []).filter((v) => v !== user_id)
                 : [...(p.likes || []), user_id],
+            }
+          : p,
+      ),
+    )
+  }
+
+  const handleRetweet = async (postId: number, rted: boolean) => {
+    const user_id = localStorage.getItem('userId') || ''
+    if (!user_id) return
+    const url = rted
+      ? `/api/posts/${postId}/unretweet`
+      : `/api/posts/${postId}/retweet`
+    await axios.post(url, { user_id })
+    setPosts((prev) =>
+      prev.map((p) =>
+        p.id === postId
+          ? {
+              ...p,
+              retweets: rted
+                ? (p.retweets || []).filter((v) => v !== user_id)
+                : [...(p.retweets || []), user_id],
             }
           : p,
       ),
@@ -258,6 +286,19 @@ export default function CommunityHome() {
                 }}
               >
                 コメント {comments[p.id]?.length || 0}
+              </button>
+              <button
+                className="underline"
+                onClick={() =>
+                  handleRetweet(
+                    p.id,
+                    (p.retweets || []).includes(
+                      localStorage.getItem('userId') || '',
+                    ),
+                  )
+                }
+              >
+                リツイート {p.retweets ? p.retweets.length : 0}
               </button>
               <button
                 className="underline"

--- a/osarebito-frontend/src/app/community/trends/page.tsx
+++ b/osarebito-frontend/src/app/community/trends/page.tsx
@@ -9,6 +9,7 @@ interface Post {
   author_id: string
   content: string
   likes?: string[]
+  retweets?: string[]
 }
 
 export default function CommunityTrends() {
@@ -40,7 +41,8 @@ export default function CommunityTrends() {
             <div className="text-sm text-gray-600">{p.author_id}</div>
             <p>{p.content}</p>
             <div className="text-xs text-gray-600 mt-1">
-              いいね {p.likes ? p.likes.length : 0}
+              いいね {p.likes ? p.likes.length : 0} / リツイート{' '}
+              {p.retweets ? p.retweets.length : 0}
             </div>
           </div>
         ))}

--- a/osarebito-frontend/src/routs.ts
+++ b/osarebito-frontend/src/routs.ts
@@ -29,6 +29,8 @@ export const updatesWsUrl = BACKEND_URL.replace(/^http/, 'ws') + '/ws/updates'
 export const bookmarkPostUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}/bookmark`
 export const unbookmarkPostUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}/unbookmark`
 export const userBookmarksUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/bookmarks`
+export const retweetPostUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}/retweet`
+export const unretweetPostUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}/unretweet`
 export const sendMessageUrl = `${BACKEND_URL}/messages`
 export const messagesWithUrl = (userId: string, otherId: string) =>
   `${BACKEND_URL}/messages/${userId}/with/${otherId}`


### PR DESCRIPTION
## Summary
- いいねに加えてリツイート機能を追加
- 通報に応じて自動でセミBANを行う処理を実装
- トレンド計算にリツイート数を反映
- フロントエンドにリツイートボタンを追加
- API ルートを拡充

## Testing
- `npm run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6881adb384f4832d8afea37c76320ce6