### PR TITLE
Add beginner tutorial feature

### DIFF
--- a/osarebito-frontend/src/app/api/users/[userId]/tutorial_tasks/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/tutorial_tasks/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { tutorialTasksUrl } from '../../../../../../routs'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export async function GET(req: NextRequest, { params }: { params: any }) {
+  try {
+    const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
+    const res = await fetch(tutorialTasksUrl(userId))
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/community/messages/[partnerId]/page.tsx
+++ b/osarebito-frontend/src/app/community/messages/[partnerId]/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react'
 import axios from 'axios'
 import { useParams } from 'next/navigation'
-import { sendMessageUrl, messagesWithUrl } from '../../../../routs'
+import { sendMessageUrl } from '../../../../routs'
 
 interface Message {
   id: number
@@ -46,7 +46,7 @@ export default function MessagesWith() {
       }
     }
     return () => ws.close()
-  }, [partnerId])
+  }, [partnerId, myId])
 
   const send = async () => {
     if (!myId || !text) return

--- a/osarebito-frontend/src/app/community/page.tsx
+++ b/osarebito-frontend/src/app/community/page.tsx
@@ -178,7 +178,7 @@ export default function CommunityHome() {
     loadComments(postId)
   }
 
-  const toggleBest = async (postId: number, commentId: number, current: boolean) => {
+  const toggleBest = async (postId: number, commentId: number) => {
     const user_id = localStorage.getItem('userId') || ''
     if (!user_id) return
     const res = await axios.put(bestAnswerUrl(postId), { comment_id: commentId, user_id })
@@ -325,7 +325,7 @@ export default function CommunityHome() {
                   {p.author_id === (typeof window !== 'undefined' ? localStorage.getItem('userId') || '' : '') && (
                     <button
                       className="ml-2 text-xs underline"
-                      onClick={() => toggleBest(p.id, c.id, p.best_answer_id === c.id)}
+                      onClick={() => toggleBest(p.id, c.id)}
                     >
                       {p.best_answer_id === c.id ? '取り消し' : 'ベスト'}
                     </button>

--- a/osarebito-frontend/src/app/community/tutorial/page.tsx
+++ b/osarebito-frontend/src/app/community/tutorial/page.tsx
@@ -1,0 +1,30 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+
+export default function CommunityTutorial() {
+  const [tasks, setTasks] = useState<string[]>([])
+
+  useEffect(() => {
+    const uid = localStorage.getItem('userId') || ''
+    if (!uid) return
+    axios.get(`/api/users/${uid}/tutorial_tasks`).then((res) => {
+      setTasks(res.data.tasks || [])
+    })
+  }, [])
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">チュートリアル</h1>
+      {tasks.length === 0 ? (
+        <p>チュートリアルタスクはありません。</p>
+      ) : (
+        <ul className="list-disc pl-6 space-y-1">
+          {tasks.map((t, idx) => (
+            <li key={idx}>{t}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/components/CommunitySidebar.tsx
+++ b/osarebito-frontend/src/components/CommunitySidebar.tsx
@@ -5,9 +5,23 @@ import {
   HashtagIcon,
   BellIcon,
   EnvelopeIcon,
+  SparklesIcon,
 } from '@heroicons/react/24/outline'
+import { useEffect, useState } from 'react'
 
 export default function CommunitySidebar() {
+  const [showTutorial, setShowTutorial] = useState(false)
+
+  useEffect(() => {
+    const uid = localStorage.getItem('userId') || ''
+    if (!uid) return
+    fetch(`/api/users/${uid}/tutorial_tasks`)
+      .then((res) => res.json())
+      .then((data) => {
+        setShowTutorial((data.tasks || []).length > 0)
+      })
+  }, [])
+
   return (
     <nav className="w-48 bg-pink-100 min-h-screen p-4 space-y-4 border-r border-pink-200">
       <h2 className="text-lg font-semibold text-pink-700">コミュニティ</h2>
@@ -31,6 +45,12 @@ export default function CommunitySidebar() {
         <span className="w-5 h-5">🔖</span>
         <span>ブックマーク</span>
       </Link>
+      {showTutorial && (
+        <Link href="/community/tutorial" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+          <SparklesIcon className="w-5 h-5" />
+          <span>チュートリアル</span>
+        </Link>
+      )}
     </nav>
   )
 }

--- a/osarebito-frontend/src/routs.ts
+++ b/osarebito-frontend/src/routs.ts
@@ -38,3 +38,4 @@ export const notificationsUrl = (userId: string) => `${BACKEND_URL}/users/${user
 export const reportPostUrl = (postId: number) => `${BACKEND_URL}/reports/post/${postId}`
 export const reportCommentUrl = (commentId: number) => `${BACKEND_URL}/reports/comment/${commentId}`
 export const trendingPostsUrl = `${BACKEND_URL}/trending_posts`
+export const tutorialTasksUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/tutorial_tasks`


### PR DESCRIPTION
## Summary
- FastAPI: store registration time and provide tutorial tasks
- Next.js: fetch tutorial tasks API and show tutorial page
- add tutorial link in the community sidebar when tasks are available

## Testing
- `python -m py_compile osarebito-backend/app/main.py`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6881b57113bc832d887b9478a56f4b26