### PR TITLE
Add achievements feature to community

### DIFF
--- a/osarebito-frontend/src/app/community/achievements/page.tsx
+++ b/osarebito-frontend/src/app/community/achievements/page.tsx
@@ -1,0 +1,31 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import { achievementsUrl } from '@/routes'
+
+export default function CommunityAchievements() {
+  const [achievements, setAchievements] = useState<string[]>([])
+
+  useEffect(() => {
+    const uid = localStorage.getItem('userId') || ''
+    if (!uid) return
+    axios.get(achievementsUrl(uid)).then((res) => {
+      setAchievements(res.data.achievements || [])
+    })
+  }, [])
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">実績</h1>
+      {achievements.length === 0 ? (
+        <p>まだ実績はありません。</p>
+      ) : (
+        <ul className="list-disc pl-4 space-y-1">
+          {achievements.map((a) => (
+            <li key={a}>{a}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/components/CommunitySidebar.tsx
+++ b/osarebito-frontend/src/components/CommunitySidebar.tsx
@@ -45,6 +45,10 @@ export default function CommunitySidebar() {
         <span className="w-5 h-5">🔖</span>
         <span>ブックマーク</span>
       </Link>
+      <Link href="/community/achievements" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <SparklesIcon className="w-5 h-5" />
+        <span>実績</span>
+      </Link>
       {showTutorial && (
         <Link href="/community/tutorial" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
           <SparklesIcon className="w-5 h-5" />

--- a/osarebito-frontend/src/routes.ts
+++ b/osarebito-frontend/src/routes.ts
@@ -39,3 +39,4 @@ export const reportPostUrl = (postId: number) => `${BACKEND_URL}/reports/post/${
 export const reportCommentUrl = (commentId: number) => `${BACKEND_URL}/reports/comment/${commentId}`
 export const trendingPostsUrl = `${BACKEND_URL}/trending_posts`
 export const tutorialTasksUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/tutorial_tasks`
+export const achievementsUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/achievements`


### PR DESCRIPTION
## Summary
- add achievement handling to backend
- unlock first post/comment achievements
- expose user achievements endpoint
- show achievements page in frontend
- link achievements in community sidebar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6881caad5884832dbe8d6f04e99787ad