### PR TITLE
Implement nested group DM

### DIFF
--- a/osarebito-frontend/src/app/community/messages/groups/[groupId]/page.tsx
+++ b/osarebito-frontend/src/app/community/messages/groups/[groupId]/page.tsx
@@ -1,0 +1,61 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import { useParams } from 'next/navigation'
+import { groupMessagesUrl } from '@/routes'
+
+interface Message { id: number; group_id: number; sender_id: string; content: string; created_at: string }
+
+export default function GroupChat() {
+  const params = useParams() as { groupId: string }
+  const gid = parseInt(params.groupId)
+  const [messages, setMessages] = useState<Message[]>([])
+  const [text, setText] = useState('')
+  const uid = typeof window !== 'undefined' ? localStorage.getItem('userId') || '' : ''
+
+  const load = async () => {
+    const res = await axios.get(groupMessagesUrl(gid))
+    setMessages(res.data.messages || [])
+  }
+
+  useEffect(() => {
+    load()
+    const ws = new WebSocket(groupMessagesUrl(gid).replace(/^http/, 'ws').replace('/groups', '/ws/updates'))
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data)
+        if (msg.type === 'group_message' && msg.group_id === gid) {
+          setMessages((prev) => [...prev, msg.message])
+        }
+      } catch {}
+    }
+    return () => ws.close()
+  }, [gid])
+
+  const send = async () => {
+    if (!uid || !text) return
+    await axios.post(groupMessagesUrl(gid), { group_id: gid, sender_id: uid, content: text })
+    setText('')
+    load()
+  }
+
+  return (
+    <div className="p-4 max-w-md mx-auto space-y-2">
+      <h1 className="text-xl font-bold mb-2">グループ {gid}</h1>
+      <div className="border p-2 h-64 overflow-y-auto space-y-1">
+        {messages.map((m) => (
+          <div key={m.id} className="text-sm">
+            <span className="mr-2 text-gray-600">{m.sender_id}:</span>
+            {m.content}
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input className="border flex-1 p-1" value={text} onChange={(e) => setText(e.target.value)} placeholder="メッセージ" />
+        <button className="bg-pink-500 text-white px-3" onClick={send}>
+          送信
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/community/messages/groups/page.tsx
+++ b/osarebito-frontend/src/app/community/messages/groups/page.tsx
@@ -1,0 +1,68 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import Link from 'next/link'
+import { createGroupUrl, userGroupsUrl } from '@/routes'
+
+interface Group { id: number; name: string; members: string[] }
+
+export default function GroupsIndex() {
+  const [groups, setGroups] = useState<Group[]>([])
+  const [name, setName] = useState('')
+  const [members, setMembers] = useState('')
+  const uid = typeof window !== 'undefined' ? localStorage.getItem('userId') || '' : ''
+
+  const load = async () => {
+    if (!uid) return
+    const res = await axios.get(userGroupsUrl(uid))
+    setGroups(res.data.groups || [])
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const create = async () => {
+    if (!uid || !name) return
+    const m = members.split(',').map((s) => s.trim()).filter((s) => s)
+    if (!m.includes(uid)) m.push(uid)
+    await axios.post(createGroupUrl, { name, members: m })
+    setName('')
+    setMembers('')
+    load()
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">グループチャット</h1>
+      <div className="space-y-2">
+        {groups.map((g) => (
+          <div key={g.id} className="border p-2">
+            <Link href={`/community/messages/groups/${g.id}`} className="underline text-pink-500">
+              {g.name}
+            </Link>
+          </div>
+        ))}
+        {groups.length === 0 && <p>グループがありません。</p>}
+      </div>
+      <div className="mt-4 space-y-2">
+        <h2 className="font-semibold">新規作成</h2>
+        <input
+          className="border p-1 w-full"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="グループ名"
+        />
+        <input
+          className="border p-1 w-full"
+          value={members}
+          onChange={(e) => setMembers(e.target.value)}
+          placeholder="メンバーのユーザーIDをカンマ区切りで入力"
+        />
+        <button className="bg-pink-500 text-white px-3" onClick={create}>
+          作成
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- コミュニティのグループDMを `messages/groups` 配下に追加
- グループ一覧ページと各グループ用ページを実装

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6881db9bdc10832db31b24178e8d1143