### PR TITLE
Add tag search to community

### DIFF
--- a/osarebito-backend/app/main.py
+++ b/osarebito-backend/app/main.py
@@ -638,6 +638,20 @@ def trending_posts():
     return {"posts": result}
 
 
+@app.get("/posts/by_tag")
+def posts_by_tag(tag: str):
+    posts = load_posts()
+    result = []
+    for p in posts:
+        if tag in p.get("tags", []):
+            item = p.copy()
+            if item.get("anonymous"):
+                item["author_id"] = "匿名"
+            result.append(item)
+    result.sort(key=lambda x: x["id"], reverse=True)
+    return {"posts": result}
+
+
 # -------------------- Like API --------------------
 
 

--- a/osarebito-frontend/src/app/api/posts/tag/[tag]/route.ts
+++ b/osarebito-frontend/src/app/api/posts/tag/[tag]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { postsByTagUrl } from '@/routes'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function GET(req: NextRequest, { params }: { params: any }) {
+  try {
+    const tag = Array.isArray(params.tag) ? params.tag[0] : params.tag
+    const res = await fetch(postsByTagUrl(tag))
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/community/tag/[tag]/page.tsx
+++ b/osarebito-frontend/src/app/community/tag/[tag]/page.tsx
@@ -1,0 +1,44 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import { useParams } from 'next/navigation'
+
+interface Post {
+  id: number
+  author_id: string
+  content: string
+  category?: string | null
+  likes?: string[]
+  retweets?: string[]
+}
+
+export default function TagPostsPage() {
+  const params = useParams() as { tag: string }
+  const tag = params.tag
+  const [posts, setPosts] = useState<Post[]>([])
+
+  useEffect(() => {
+    axios.get(`/api/posts/tag/${encodeURIComponent(tag)}`).then((res) => {
+      setPosts(res.data.posts || [])
+    })
+  }, [tag])
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">#{tag} の投稿</h1>
+      {posts.map((p) => (
+        <div key={p.id} className="border p-2">
+          <div className="text-sm text-gray-600">{p.author_id}</div>
+          {p.category && (
+            <div className="text-xs text-pink-600 mb-1">[{p.category}]</div>
+          )}
+          <p>{p.content}</p>
+          <div className="text-xs text-gray-600 mt-1">
+            いいね {p.likes ? p.likes.length : 0} / リツイート{' '}
+            {p.retweets ? p.retweets.length : 0}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/community/trends/page.tsx
+++ b/osarebito-frontend/src/app/community/trends/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
 import axios from 'axios'
+import Link from 'next/link'
 import { trendingPostsUrl } from '@/routes'
 
 interface Tag { name: string; count: number }
@@ -28,9 +29,13 @@ export default function CommunityTrends() {
         <h2 className="font-semibold mb-2">人気タグ</h2>
         <div className="flex flex-wrap gap-2">
           {tags.map((t) => (
-            <span key={t.name} className="bg-pink-100 px-2 py-1 text-sm">
+            <Link
+              key={t.name}
+              href={`/community/tag/${encodeURIComponent(t.name)}`}
+              className="bg-pink-100 px-2 py-1 text-sm underline"
+            >
               #{t.name} ({t.count})
-            </span>
+            </Link>
           ))}
         </div>
       </section>

--- a/osarebito-frontend/src/routes.ts
+++ b/osarebito-frontend/src/routes.ts
@@ -38,6 +38,8 @@ export const notificationsUrl = (userId: string) => `${BACKEND_URL}/users/${user
 export const reportPostUrl = (postId: number) => `${BACKEND_URL}/reports/post/${postId}`
 export const reportCommentUrl = (commentId: number) => `${BACKEND_URL}/reports/comment/${commentId}`
 export const trendingPostsUrl = `${BACKEND_URL}/trending_posts`
+export const postsByTagUrl = (tag: string) =>
+  `${BACKEND_URL}/posts/by_tag?tag=${encodeURIComponent(tag)}`
 export const tutorialTasksUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/tutorial_tasks`
 export const achievementsUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/achievements`
 export const jobsUrl = `${BACKEND_URL}/jobs`


### PR DESCRIPTION
## Summary
- add `/posts/by_tag` endpoint
- add frontend API route for tag search
- add tag post list page and link from trends page
- expose postsByTagUrl in routes

## Testing
- `python -m py_compile osarebito-backend/app/main.py`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6881f3e1174c832da6438f31cd9d073e