### PR TITLE
コミュニティ機能の拡充: ブロック機能などを追加

### DIFF
--- a/osarebito-frontend/src/app/api/users/[userId]/block/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/block/route.ts
@@ -1,14 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getUserUrl } from '@/routes'
+import { blockUserUrl } from '@/routes'
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export async function GET(req: NextRequest, { params }: { params: any }) {
+export async function POST(req: NextRequest, { params }: { params: any }) {
   try {
+    const data = await req.json()
     const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
-    const url = new URL(getUserUrl(userId))
-    const viewer = req.nextUrl.searchParams.get('viewer_id')
-    if (viewer) url.searchParams.set('viewer_id', viewer)
-    const res = await fetch(url)
+    const res = await fetch(blockUserUrl(userId), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
     const body = await res.json()
     if (!res.ok) {
       return NextResponse.json({ detail: body.detail }, { status: res.status })

--- a/osarebito-frontend/src/app/api/users/[userId]/unblock/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/unblock/route.ts
@@ -1,14 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getUserUrl } from '@/routes'
+import { unblockUserUrl } from '@/routes'
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export async function GET(req: NextRequest, { params }: { params: any }) {
+export async function POST(req: NextRequest, { params }: { params: any }) {
   try {
+    const data = await req.json()
     const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
-    const url = new URL(getUserUrl(userId))
-    const viewer = req.nextUrl.searchParams.get('viewer_id')
-    if (viewer) url.searchParams.set('viewer_id', viewer)
-    const res = await fetch(url)
+    const res = await fetch(unblockUserUrl(userId), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
     const body = await res.json()
     if (!res.ok) {
       return NextResponse.json({ detail: body.detail }, { status: res.status })

--- a/osarebito-frontend/src/app/profile/[userId]/page.tsx
+++ b/osarebito-frontend/src/app/profile/[userId]/page.tsx
@@ -4,6 +4,7 @@ import { getUserUrl } from '@/routes'
 import FollowButton from '../../../components/FollowButton'
 import InterestButton from '../../../components/InterestButton'
 import MutualLink from '../../../components/MutualLink'
+import BlockButton from '../../../components/BlockButton'
 
 async function getUser(userId: string) {
   const res = await fetch(getUserUrl(userId), { cache: 'no-store' })
@@ -37,6 +38,7 @@ export default async function Profile({ params }: any) {
         <MutualLink targetId={params.userId} />
         <FollowButton targetId={params.userId} followers={user.followers || []} />
         <InterestButton targetId={params.userId} interested={interested} />
+        <BlockButton targetId={params.userId} />
       </div>
       {profile.profile_image && (
         <Image src={profile.profile_image} alt="profile" width={200} height={200} className="mt-2" />

--- a/osarebito-frontend/src/components/BlockButton.tsx
+++ b/osarebito-frontend/src/components/BlockButton.tsx
@@ -1,0 +1,46 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import axios from 'axios'
+
+interface Props {
+  targetId: string
+}
+
+export default function BlockButton({ targetId }: Props) {
+  const [ready, setReady] = useState(false)
+  const [blocked, setBlocked] = useState(false)
+  const router = useRouter()
+
+  useEffect(() => {
+    const myId = localStorage.getItem('userId') || ''
+    if (!myId) {
+      setReady(true)
+      return
+    }
+    axios.get(`/api/users/${myId}`).then((res) => {
+      setBlocked((res.data.blocks || []).includes(targetId))
+      setReady(true)
+    })
+  }, [targetId])
+
+  const handleClick = async () => {
+    const myId = localStorage.getItem('userId') || ''
+    if (!myId || myId === targetId) return
+    const payload = { user_id: myId }
+    if (blocked) {
+      await axios.post(`/api/users/${targetId}/unblock`, payload)
+    } else {
+      await axios.post(`/api/users/${targetId}/block`, payload)
+    }
+    setBlocked(!blocked)
+    router.refresh()
+  }
+
+  if (!ready) return null
+  return (
+    <button className="bg-red-500 text-white px-4 py-1" onClick={handleClick}>
+      {blocked ? 'ブロック解除' : 'ブロック'}
+    </button>
+  )
+}

--- a/osarebito-frontend/src/routes.ts
+++ b/osarebito-frontend/src/routes.ts
@@ -8,6 +8,8 @@ export const followUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}
 export const unfollowUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/unfollow`
 export const interestUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/interest`
 export const uninterestUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/uninterest`
+export const blockUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/block`
+export const unblockUserUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/unblock`
 export const mutualFollowersUrl = (userId: string, myId: string) =>
   `${BACKEND_URL}/users/${userId}/mutual_followers?my_id=${myId}`
 export const followersUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/followers`


### PR DESCRIPTION
## 追加内容
- ユーザープロフィール取得時の公開範囲チェック追加
- ユーザーをブロック/解除できるAPIとフロント側ルートを追加
- ブロックボタンのコンポーネントを実装しプロフィール画面に配置
- ブロック状態を考慮したフォロー・投稿・メッセージ処理をサーバ側で実装
- ルート定義の更新

## テスト
- `npm run lint`
- `npm run build`
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68824241e6e0832d8f1ea776a9748246