### PR TITLE
Automate backend virtual env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,15 @@ python migrate_json.py
 
 ```bash
 # バックエンド
-python run_backend.py
+python run_backend.py  # 初回実行時に仮想環境を自動生成
+
+# Windows の場合
+run_backend.bat
 
 # フロントエンド
 npm --prefix osarebito-frontend run dev
 ```
+
+`run_backend.py` は仮想環境が存在しない場合、自動で作成して必要な
+依存パッケージをインストールします。これにより、複数の PC でクローン
+した直後でも同じ手順でデバッグを開始できます。

--- a/run_backend.bat
+++ b/run_backend.bat
@@ -1,0 +1,13 @@
+@echo off
+set SCRIPT_DIR=%~dp0
+cd /d "%SCRIPT_DIR%osarebito-backend"
+if not exist venv\Scripts\python.exe (
+  echo Creating virtual environment...
+  python -m venv venv || exit /b 1
+  venv\Scripts\python.exe -m pip install --upgrade pip
+  if exist requirements.txt (
+    venv\Scripts\python.exe -m pip install -r requirements.txt
+  )
+)
+venv\Scripts\python.exe -m uvicorn app.main:app --reload --host %BACKEND_HOST% --port %BACKEND_PORT%
+

--- a/run_backend.py
+++ b/run_backend.py
@@ -10,10 +10,32 @@ BACKEND_PYTHON = VENV_BIN / ("python.exe" if os.name == "nt" else "python")
 BACKEND_UVICORN = VENV_BIN / ("uvicorn.exe" if os.name == "nt" else "uvicorn")
 
 
+def ensure_virtualenv() -> None:
+    """Create a virtual environment and install dependencies if needed."""
+    global BACKEND_PYTHON, BACKEND_UVICORN
+    if BACKEND_PYTHON.exists():
+        return
+
+    print("Creating virtual environment...")
+    subprocess.run([sys.executable, "-m", "venv", "venv"], cwd=BACKEND_DIR, check=True)
+
+    # Update BACKEND_PYTHON path after creation
+    BACKEND_PYTHON = VENV_BIN / ("python.exe" if os.name == "nt" else "python")
+    BACKEND_UVICORN = VENV_BIN / ("uvicorn.exe" if os.name == "nt" else "uvicorn")
+
+    print("Installing backend dependencies...")
+    subprocess.run([str(BACKEND_PYTHON), "-m", "pip", "install", "--upgrade", "pip"], cwd=BACKEND_DIR, check=True)
+    requirements = BACKEND_DIR / "requirements.txt"
+    if requirements.exists():
+        subprocess.run([str(BACKEND_PYTHON), "-m", "pip", "install", "-r", str(requirements)], cwd=BACKEND_DIR, check=True)
+
+
 def main() -> None:
     """Start the FastAPI backend with Uvicorn."""
     host = os.environ.get("BACKEND_HOST", "127.0.0.1")
     port = os.environ.get("BACKEND_PORT", "8000")
+
+    ensure_virtualenv()
 
     if BACKEND_PYTHON.exists():
         cmd = [str(BACKEND_PYTHON), "-m", "uvicorn", "app.main:app", "--reload"]


### PR DESCRIPTION
## Summary
- backendの仮想環境を自動で作成/依存解決する`ensure_virtualenv`を追加
- Windows用起動スクリプト`run_backend.bat`を追加
- READMEに起動手順を更新し、自動環境構築について追記

## Testing
- `python -m py_compile run_backend.py`
- `python -m py_compile run_frontend.py`


------
https://chatgpt.com/codex/tasks/task_e_6883fe94c838832db674d85ba5d090a6