### PR TITLE
Adjust noise dot opacity

### DIFF
--- a/osarebito-frontend/src/app/imagetool/page.tsx
+++ b/osarebito-frontend/src/app/imagetool/page.tsx
@@ -51,7 +51,7 @@ async function compressImage(file: File, ai: boolean): Promise<Blob> {
 
     // Add semi-transparent noise dots at wider intervals
     const dotSpacing = 5 // pixels between noise dots
-    const opacity = 0.3 // noise opacity
+    const opacity = 0.1 // noise opacity (lower for higher transparency)
 
     for (let y = 0; y < canvas.height; y += dotSpacing) {
       for (let x = 0; x < canvas.width; x += dotSpacing) {


### PR DESCRIPTION
## Summary
- ノイズドットの透明度を上げてAI対策を軽減

## Testing
- `npm --prefix osarebito-frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_68863c2eb92c832daf7e100d81cdb2b1