### PR TITLE
Fix posts filter query

### DIFF
--- a/osarebito-frontend/src/app/api/posts/route.ts
+++ b/osarebito-frontend/src/app/api/posts/route.ts
@@ -4,9 +4,10 @@ import { postsUrl, createPostUrl } from '@/routes'
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url)
-    const feed = searchParams.get('feed') || 'all'
-    const user_id = searchParams.get('user_id') || undefined
-    const url = postsUrl(feed, user_id || undefined)
+  const feed = searchParams.get('feed') || 'all'
+  const user_id = searchParams.get('user_id') || undefined
+  const category = searchParams.get('category') || undefined
+  const url = postsUrl(feed, user_id || undefined, category || undefined)
     const res = await fetch(url)
     const body = await res.json()
     if (!res.ok) {

--- a/osarebito-frontend/src/routes.ts
+++ b/osarebito-frontend/src/routes.ts
@@ -14,9 +14,14 @@ export const mutualFollowersUrl = (userId: string, myId: string) =>
   `${BACKEND_URL}/users/${userId}/mutual_followers?my_id=${myId}`
 export const followersUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/followers`
 export const followingUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/following`
-export const postsUrl = (feed: string, userId?: string) => {
+export const postsUrl = (
+  feed: string,
+  userId?: string,
+  category?: string,
+) => {
   const params = new URLSearchParams({ feed })
   if (userId) params.append('user_id', userId)
+  if (category) params.append('category', category)
   return `${BACKEND_URL}/posts?${params.toString()}`
 }
 export const createPostUrl = `${BACKEND_URL}/posts`


### PR DESCRIPTION
## Summary
- forward `category` parameter when fetching posts
- accept category argument in `postsUrl`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6886cab93d80832d8adbe046350ef481