### PR TITLE
Fix icons in CommunitySidebar

### DIFF
--- a/osarebito-frontend/src/components/CommunitySidebar.tsx
+++ b/osarebito-frontend/src/components/CommunitySidebar.tsx
@@ -7,6 +7,8 @@ import {
   EnvelopeIcon,
   BriefcaseIcon,
   SparklesIcon,
+  UserGroupIcon,
+  BookmarkIcon,
 } from '@heroicons/react/24/outline'
 import { useEffect, useState } from 'react'
 
@@ -43,11 +45,11 @@ export default function CommunitySidebar() {
         <span>メッセージ</span>
       </Link>
       <Link href="/community/groups" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
-        <span className="w-5 h-5">👥</span>
+        <UserGroupIcon className="w-5 h-5" />
         <span>グループ</span>
       </Link>
       <Link href="/community/bookmarks" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
-        <span className="w-5 h-5">🔖</span>
+        <BookmarkIcon className="w-5 h-5" />
         <span>ブックマーク</span>
       </Link>
       <Link href="/community/jobs" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">


### PR DESCRIPTION
## Summary
- use heroicons for group and bookmark instead of emoji

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6886d6537bec832d83b74316bc5485d7