### PR TITLE
モダンなコミュニティUI

### DIFF
--- a/osarebito-frontend/src/app/community/achievements/page.tsx
+++ b/osarebito-frontend/src/app/community/achievements/page.tsx
@@ -20,9 +20,11 @@ export default function CommunityAchievements() {
       {achievements.length === 0 ? (
         <p>まだ実績はありません。</p>
       ) : (
-        <ul className="list-disc pl-4 space-y-1">
+        <ul className="space-y-2">
           {achievements.map((a) => (
-            <li key={a}>{a}</li>
+            <li key={a} className="border rounded-lg bg-white p-2 shadow text-sm">
+              {a}
+            </li>
           ))}
         </ul>
       )}

--- a/osarebito-frontend/src/app/community/bookmarks/page.tsx
+++ b/osarebito-frontend/src/app/community/bookmarks/page.tsx
@@ -26,7 +26,7 @@ export default function CommunityBookmarks() {
     <div>
       <h1 className="text-xl font-bold mb-4">ブックマーク一覧</h1>
       {posts.map((p) => (
-        <div key={p.id} className="border p-3 mb-3">
+        <div key={p.id} className="border rounded-lg bg-white p-4 shadow mb-3">
           <div className="text-sm text-gray-600">{p.author_id}</div>
           {p.category && (
             <div className="text-xs text-pink-600 mb-1">[{p.category}]</div>

--- a/osarebito-frontend/src/app/community/groups/[groupId]/page.tsx
+++ b/osarebito-frontend/src/app/community/groups/[groupId]/page.tsx
@@ -42,7 +42,7 @@ export default function GroupChat() {
   return (
     <div className="p-4 max-w-md mx-auto space-y-2">
       <h1 className="text-xl font-bold mb-2">グループ {gid}</h1>
-      <div className="border p-2 h-64 overflow-y-auto space-y-1">
+      <div className="border rounded-lg bg-white p-2 h-64 overflow-y-auto space-y-1 shadow">
         {messages.map((m) => (
           <div key={m.id} className="text-sm">
             <span className="mr-2 text-gray-600">{m.sender_id}:</span>
@@ -51,8 +51,8 @@ export default function GroupChat() {
         ))}
       </div>
       <div className="flex gap-2">
-        <input className="border flex-1 p-1" value={text} onChange={(e) => setText(e.target.value)} placeholder="メッセージ" />
-        <button className="bg-pink-500 text-white px-3" onClick={send}>
+        <input className="border rounded flex-1 p-1" value={text} onChange={(e) => setText(e.target.value)} placeholder="メッセージ" />
+        <button className="bg-pink-500 hover:bg-pink-600 text-white rounded px-3 transition" onClick={send}>
           送信
         </button>
       </div>

--- a/osarebito-frontend/src/app/community/groups/page.tsx
+++ b/osarebito-frontend/src/app/community/groups/page.tsx
@@ -37,7 +37,7 @@ export default function GroupsIndex() {
       <h1 className="text-xl font-bold">グループチャット</h1>
       <div className="space-y-2">
         {groups.map((g) => (
-          <div key={g.id} className="border p-2">
+          <div key={g.id} className="border rounded-lg bg-white p-3 shadow">
             <Link href={`/community/groups/${g.id}`} className="underline text-pink-500">
               {g.name}
             </Link>
@@ -48,18 +48,18 @@ export default function GroupsIndex() {
       <div className="mt-4 space-y-2">
         <h2 className="font-semibold">新規作成</h2>
         <input
-          className="border p-1 w-full"
+          className="border rounded p-1 w-full"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="グループ名"
         />
         <input
-          className="border p-1 w-full"
+          className="border rounded p-1 w-full"
           value={members}
           onChange={(e) => setMembers(e.target.value)}
           placeholder="メンバーのユーザーIDをカンマ区切りで入力"
         />
-        <button className="bg-pink-500 text-white px-3" onClick={create}>
+        <button className="bg-pink-500 hover:bg-pink-600 text-white rounded px-3 transition" onClick={create}>
           作成
         </button>
       </div>

--- a/osarebito-frontend/src/app/community/jobs/page.tsx
+++ b/osarebito-frontend/src/app/community/jobs/page.tsx
@@ -57,39 +57,39 @@ export default function CommunityJobs() {
   return (
     <div className="space-y-4">
       <h1 className="text-xl font-bold">依頼掲示板</h1>
-      <div className="space-y-2 border p-3">
+      <div className="space-y-2 border rounded-lg bg-white p-3 shadow">
         <input
-          className="border p-1 w-full"
+          className="border rounded p-1 w-full"
           placeholder="タイトル"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
         />
         <textarea
-          className="border p-1 w-full"
+          className="border rounded p-1 w-full"
           rows={3}
           placeholder="依頼内容"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
         />
         <input
-          className="border p-1 w-full"
+          className="border rounded p-1 w-full"
           placeholder="報酬 (任意)"
           value={reward}
           onChange={(e) => setReward(e.target.value)}
         />
         <input
-          className="border p-1 w-full"
+          className="border rounded p-1 w-full"
           placeholder="締切 (任意)"
           value={deadline}
           onChange={(e) => setDeadline(e.target.value)}
         />
-        <button className="bg-pink-500 text-white px-3" onClick={submit}>
+        <button className="bg-pink-500 hover:bg-pink-600 text-white rounded px-3 transition" onClick={submit}>
           投稿
         </button>
       </div>
       <div className="space-y-4">
         {jobs.map((j) => (
-          <div key={j.id} className="border p-3">
+          <div key={j.id} className="border rounded-lg bg-white p-4 shadow">
             <div className="text-sm text-gray-600">{j.author_id}</div>
             <h2 className="font-semibold">{j.title}</h2>
             <p className="whitespace-pre-wrap">{j.description}</p>

--- a/osarebito-frontend/src/app/community/messages/[partnerId]/page.tsx
+++ b/osarebito-frontend/src/app/community/messages/[partnerId]/page.tsx
@@ -62,7 +62,7 @@ export default function MessagesWith() {
   return (
     <div className="p-4 max-w-md mx-auto space-y-2">
       <h1 className="text-xl font-bold mb-2">{partnerId}とのメッセージ</h1>
-      <div className="border p-2 h-64 overflow-y-auto space-y-1">
+      <div className="border rounded-lg bg-white p-2 h-64 overflow-y-auto space-y-1 shadow">
         {messages.map((m) => (
           <div key={m.id} className="text-sm">
             <span className="mr-2 text-gray-600">{m.sender_id}:</span>
@@ -72,12 +72,12 @@ export default function MessagesWith() {
       </div>
       <div className="flex gap-2">
         <input
-          className="border flex-1 p-1"
+          className="border rounded flex-1 p-1"
           value={text}
           onChange={(e) => setText(e.target.value)}
           placeholder="メッセージを入力"
         />
-        <button className="bg-pink-500 text-white px-3" onClick={send}>
+        <button className="bg-pink-500 hover:bg-pink-600 text-white rounded px-3 transition" onClick={send}>
           送信
         </button>
       </div>

--- a/osarebito-frontend/src/app/community/messages/groups/[groupId]/page.tsx
+++ b/osarebito-frontend/src/app/community/messages/groups/[groupId]/page.tsx
@@ -42,7 +42,7 @@ export default function GroupChat() {
   return (
     <div className="p-4 max-w-md mx-auto space-y-2">
       <h1 className="text-xl font-bold mb-2">グループ {gid}</h1>
-      <div className="border p-2 h-64 overflow-y-auto space-y-1">
+      <div className="border rounded-lg bg-white p-2 h-64 overflow-y-auto space-y-1 shadow">
         {messages.map((m) => (
           <div key={m.id} className="text-sm">
             <span className="mr-2 text-gray-600">{m.sender_id}:</span>
@@ -51,8 +51,8 @@ export default function GroupChat() {
         ))}
       </div>
       <div className="flex gap-2">
-        <input className="border flex-1 p-1" value={text} onChange={(e) => setText(e.target.value)} placeholder="メッセージ" />
-        <button className="bg-pink-500 text-white px-3" onClick={send}>
+        <input className="border rounded flex-1 p-1" value={text} onChange={(e) => setText(e.target.value)} placeholder="メッセージ" />
+        <button className="bg-pink-500 hover:bg-pink-600 text-white rounded px-3 transition" onClick={send}>
           送信
         </button>
       </div>

--- a/osarebito-frontend/src/app/community/messages/groups/page.tsx
+++ b/osarebito-frontend/src/app/community/messages/groups/page.tsx
@@ -37,7 +37,7 @@ export default function GroupsIndex() {
       <h1 className="text-xl font-bold">グループチャット</h1>
       <div className="space-y-2">
         {groups.map((g) => (
-          <div key={g.id} className="border p-2">
+          <div key={g.id} className="border rounded-lg bg-white p-3 shadow">
             <Link href={`/community/messages/groups/${g.id}`} className="underline text-pink-500">
               {g.name}
             </Link>
@@ -48,18 +48,18 @@ export default function GroupsIndex() {
       <div className="mt-4 space-y-2">
         <h2 className="font-semibold">新規作成</h2>
         <input
-          className="border p-1 w-full"
+          className="border rounded p-1 w-full"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="グループ名"
         />
         <input
-          className="border p-1 w-full"
+          className="border rounded p-1 w-full"
           value={members}
           onChange={(e) => setMembers(e.target.value)}
           placeholder="メンバーのユーザーIDをカンマ区切りで入力"
         />
-        <button className="bg-pink-500 text-white px-3" onClick={create}>
+        <button className="bg-pink-500 hover:bg-pink-600 text-white rounded px-3 transition" onClick={create}>
           作成
         </button>
       </div>

--- a/osarebito-frontend/src/app/community/notifications/page.tsx
+++ b/osarebito-frontend/src/app/community/notifications/page.tsx
@@ -28,7 +28,7 @@ export default function CommunityNotifications() {
       ) : (
         <ul className="space-y-2">
           {notes.map((n, idx) => (
-            <li key={idx} className="text-sm">
+            <li key={idx} className="text-sm border rounded-lg bg-white p-2 shadow">
               {n.type === 'message' && n.from ? (
                 <span>{n.from} からメッセージが届きました。</span>
               ) : n.type === 'follow' && n.from ? (

--- a/osarebito-frontend/src/app/community/page.tsx
+++ b/osarebito-frontend/src/app/community/page.tsx
@@ -218,37 +218,37 @@ export default function CommunityHome() {
   }
 
   return (
-    <div className="flex gap-4">
+    <div className="flex gap-6">
       <div className="flex-1 max-w-2xl">
         <div className="mb-4 flex gap-2">
           <button
-            className={`px-3 py-1 border ${feed === 'all' ? 'bg-pink-500 text-white' : ''}`}
+            className={`px-3 py-1 rounded border shadow-sm transition-colors ${feed === 'all' ? 'bg-pink-500 text-white' : 'bg-white hover:bg-gray-50'}`}
             onClick={() => setFeed('all')}
           >
             すべて
           </button>
           <button
-            className={`px-3 py-1 border ${feed === 'following' ? 'bg-pink-500 text-white' : ''}`}
+            className={`px-3 py-1 rounded border shadow-sm transition-colors ${feed === 'following' ? 'bg-pink-500 text-white' : 'bg-white hover:bg-gray-50'}`}
             onClick={() => setFeed('following')}
           >
             フォロー中
           </button>
-          <select className="border" value={category} onChange={(e) => setCategory(e.target.value)}>
+          <select className="border rounded px-2" value={category} onChange={(e) => setCategory(e.target.value)}>
             <option value="">カテゴリ指定なし</option>
             <option value="お悩み相談">お悩み相談</option>
             <option value="コラボ募集">コラボ募集</option>
             <option value="雑談">雑談</option>
           </select>
         </div>
-        <div className="mb-4 flex gap-2">
+        <div className="mb-6 flex gap-2">
           <textarea
-            className="border p-2 flex-1"
+            className="border rounded p-2 flex-1"
             rows={3}
             value={newPost}
             onChange={(e) => setNewPost(e.target.value)}
             placeholder="いまどうしてる？"
           />
-          <select className="border" value={newCategory} onChange={(e) => setNewCategory(e.target.value)}>
+          <select className="border rounded px-2" value={newCategory} onChange={(e) => setNewCategory(e.target.value)}>
             <option value="">カテゴリなし</option>
             <option value="お悩み相談">お悩み相談</option>
             <option value="コラボ募集">コラボ募集</option>
@@ -258,12 +258,12 @@ export default function CommunityHome() {
             <input type="checkbox" checked={anonymous} onChange={(e) => setAnonymous(e.target.checked)} />
             匿名
           </label>
-          <button className="bg-pink-500 text-white px-4" onClick={submitPost}>
+          <button className="bg-pink-500 hover:bg-pink-600 text-white rounded px-4 transition" onClick={submitPost}>
             投稿
           </button>
         </div>
         {posts.map((p) => (
-          <div key={p.id} id={`post-${p.id}`} className="border p-3 mb-3">
+          <div key={p.id} id={`post-${p.id}`} className="border rounded-lg bg-white p-4 shadow mb-4">
             <div className="text-sm text-gray-600">{p.author_id}</div>
             {p.category && (
               <div className="text-xs text-pink-600 mb-1">[{p.category}]</div>
@@ -353,7 +353,7 @@ export default function CommunityHome() {
                 ))}
                 <div className="flex gap-2">
                   <input
-                    className="border flex-1 p-1 text-sm"
+                    className="border rounded flex-1 p-1 text-sm"
                     value={commentText[p.id] || ''}
                     onChange={(e) =>
                       setCommentText((t) => ({ ...t, [p.id]: e.target.value }))
@@ -361,7 +361,7 @@ export default function CommunityHome() {
                     placeholder="コメントする"
                   />
                   <button
-                    className="bg-pink-500 text-white px-2"
+                    className="bg-pink-500 hover:bg-pink-600 text-white rounded px-2 transition"
                     onClick={() => submitComment(p.id)}
                   >
                     送信
@@ -376,12 +376,12 @@ export default function CommunityHome() {
         <div>
           <div className="flex gap-2 mb-2">
             <input
-              className="border p-1 flex-1"
+              className="border rounded p-1 flex-1"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="ユーザー検索"
             />
-            <button className="bg-pink-500 text-white px-2" onClick={doSearch}>
+            <button className="bg-pink-500 hover:bg-pink-600 text-white rounded px-2 transition" onClick={doSearch}>
               検索
             </button>
           </div>

--- a/osarebito-frontend/src/app/community/tag/[tag]/page.tsx
+++ b/osarebito-frontend/src/app/community/tag/[tag]/page.tsx
@@ -28,7 +28,7 @@ export default function TagPostsPage() {
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">#{tag} の投稿</h1>
       {posts.map((p) => (
-        <div key={p.id} className="border p-2">
+        <div key={p.id} className="border rounded-lg bg-white p-3 shadow">
           <div className="text-sm text-gray-600">{p.author_id}</div>
           {p.category && (
             <div className="text-xs text-pink-600 mb-1">[{p.category}]</div>

--- a/osarebito-frontend/src/app/community/trends/page.tsx
+++ b/osarebito-frontend/src/app/community/trends/page.tsx
@@ -46,7 +46,7 @@ export default function CommunityTrends() {
       <section>
         <h2 className="font-semibold mb-2">人気投稿</h2>
         {posts.map((p) => (
-          <div key={p.id} className="border p-2 mb-2">
+          <div key={p.id} className="border rounded-lg bg-white p-3 mb-3 shadow">
             <div className="text-sm text-gray-600">{p.author_id}</div>
             <p>{p.content}</p>
             <div className="text-xs text-gray-600 mt-1 flex items-center gap-4">

--- a/osarebito-frontend/src/app/community/tutorial/page.tsx
+++ b/osarebito-frontend/src/app/community/tutorial/page.tsx
@@ -19,9 +19,11 @@ export default function CommunityTutorial() {
       {tasks.length === 0 ? (
         <p>チュートリアルタスクはありません。</p>
       ) : (
-        <ul className="list-disc pl-6 space-y-1">
+        <ul className="space-y-2">
           {tasks.map((t, idx) => (
-            <li key={idx}>{t}</li>
+            <li key={idx} className="border rounded-lg bg-white p-2 shadow text-sm">
+              {t}
+            </li>
           ))}
         </ul>
       )}

--- a/osarebito-frontend/src/app/globals.css
+++ b/osarebito-frontend/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #fff8f0;
+  --background: #f0f2f5;
   --foreground: #111111;
   --accent: #ec4899;
 }
@@ -23,5 +23,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }


### PR DESCRIPTION
## Summary
- コミュニティページのボタンや投稿をカード風デザインに変更
- 各種サブページ（ブックマーク、グループ、メッセージ等）のUIを調整
- globals.css を更新し、背景色とフォントを刷新

## Testing
- `npm --prefix osarebito-frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_68871ca7f568832d99acac2b83283585