### PR TITLE
Adjust AI noise opacity

### DIFF
--- a/osarebito-frontend/src/app/imagetool/page.tsx
+++ b/osarebito-frontend/src/app/imagetool/page.tsx
@@ -51,7 +51,7 @@ async function compressImage(file: File, ai: boolean): Promise<Blob> {
 
     // Add semi-transparent noise dots at wider intervals
     const dotSpacing = 5 // pixels between noise dots
-    const opacity = 0.1 // noise opacity (lower for higher transparency)
+    const opacity = 0.05 // noise opacity (lower for higher transparency)
 
     for (let y = 0; y < canvas.height; y += dotSpacing) {
       for (let x = 0; x < canvas.width; x += dotSpacing) {


### PR DESCRIPTION
## Summary
- increase transparency of noise dots in AI option

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887987b429c832d9a635e506ad32119