### PR TITLE
Implement fan board

### DIFF
--- a/osarebito-backend/app/db.py
+++ b/osarebito-backend/app/db.py
@@ -61,6 +61,13 @@ group_messages_table = Table(
     Column("data", JSON, nullable=False),
 )
 
+fan_posts_table = Table(
+    "fan_posts",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("data", JSON, nullable=False),
+)
+
 metadata.create_all(engine)
 
 


### PR DESCRIPTION
## Summary
- add `fan_posts` table to database
- support load/save helpers for fan board
- create `FanPost` models and API endpoints

## Testing
- `python -m py_compile osarebito-backend/app/main.py osarebito-backend/app/db.py`


------
https://chatgpt.com/codex/tasks/task_e_688799631908832d8c2c9ce96ed536f5