### PR TITLE
Fix bookmarks API route

### DIFF
--- a/osarebito-frontend/src/app/api/users/[userId]/bookmarks/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/bookmarks/route.ts
@@ -3,8 +3,9 @@ import type { NextRequest } from 'next/server'
 import { userBookmarksUrl } from '@/routes'
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export async function GET(req: NextRequest, { params }: { params: any }) {
+export async function GET(req: NextRequest, context: { params: any }) {
   try {
+    const { params } = await context
     const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
     const res = await fetch(userBookmarksUrl(userId))
     const body = await res.json()


### PR DESCRIPTION
## Summary
- fix bookmarks API route by awaiting `params` from context

## Testing
- `npm --prefix osarebito-frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887983db710832dbefbd2bca63926a3