### PR TITLE
Add fan posts feature

### DIFF
--- a/osarebito-frontend/src/app/community/fan_posts/page.tsx
+++ b/osarebito-frontend/src/app/community/fan_posts/page.tsx
@@ -1,0 +1,83 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import { fanPostsUrl } from '@/routes'
+
+interface FanPost {
+  id: number
+  author_id: string
+  content: string
+  created_at: string
+}
+
+export default function FanPosts() {
+  const [posts, setPosts] = useState<FanPost[]>([])
+  const [content, setContent] = useState('')
+  const [error, setError] = useState('')
+  const uid = typeof window !== 'undefined' ? localStorage.getItem('userId') || '' : ''
+
+  const load = async () => {
+    if (!uid) return
+    try {
+      const res = await axios.get(`${fanPostsUrl}?viewer_id=${uid}`)
+      setPosts(res.data.posts || [])
+      setError('')
+    } catch (e) {
+      if (axios.isAxiosError(e) && e.response?.status === 403) {
+        setError('ファン専用の掲示板です。')
+      } else {
+        setError('読み込みに失敗しました')
+      }
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [uid])
+
+  const submit = async () => {
+    if (!uid || !content) return
+    try {
+      await axios.post(fanPostsUrl, { author_id: uid, content })
+      setContent('')
+      load()
+    } catch {
+      alert('投稿に失敗しました')
+    }
+  }
+
+  if (!uid) {
+    return <p className="p-4">ログインしてください。</p>
+  }
+
+  if (error) {
+    return <p className="p-4">{error}</p>
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">ファン掲示板</h1>
+      <div className="space-y-2 border rounded-lg bg-white p-3 shadow">
+        <textarea
+          className="border rounded p-1 w-full"
+          rows={3}
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="投稿内容"
+        />
+        <button className="bg-pink-500 hover:bg-pink-600 text-white rounded px-3 transition" onClick={submit}>
+          投稿
+        </button>
+      </div>
+      <div className="space-y-4">
+        {posts.map((p) => (
+          <div key={p.id} className="border rounded-lg bg-white p-4 shadow">
+            <div className="text-sm text-gray-600">{p.author_id}</div>
+            <p className="whitespace-pre-wrap">{p.content}</p>
+          </div>
+        ))}
+        {posts.length === 0 && <p>投稿はありません。</p>}
+      </div>
+    </div>
+  )
+}

--- a/osarebito-frontend/src/components/CommunitySidebar.tsx
+++ b/osarebito-frontend/src/components/CommunitySidebar.tsx
@@ -9,6 +9,7 @@ import {
   SparklesIcon,
   UserGroupIcon,
   BookmarkIcon,
+  PaintBrushIcon,
 } from '@heroicons/react/24/outline'
 import { useEffect, useState } from 'react'
 
@@ -55,6 +56,10 @@ export default function CommunitySidebar() {
       <Link href="/community/jobs" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
         <BriefcaseIcon className="w-5 h-5" />
         <span>依頼掲示板</span>
+      </Link>
+      <Link href="/community/fan_posts" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <PaintBrushIcon className="w-5 h-5" />
+        <span>ファン掲示板</span>
       </Link>
       <Link href="/community/achievements" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
         <SparklesIcon className="w-5 h-5" />

--- a/osarebito-frontend/src/routes.ts
+++ b/osarebito-frontend/src/routes.ts
@@ -53,3 +53,4 @@ export const jobsUrl = `${BACKEND_URL}/jobs`
 export const createGroupUrl = `${BACKEND_URL}/groups`
 export const userGroupsUrl = (userId: string) => `${BACKEND_URL}/groups/${userId}`
 export const groupMessagesUrl = (groupId: number) => `${BACKEND_URL}/groups/${groupId}/messages`
+export const fanPostsUrl = `${BACKEND_URL}/fan_posts`


### PR DESCRIPTION
## Summary
- コミュニティサイドバーにファン掲示板へのリンクを追加
- ファン専用掲示板ページを実装
- ルート定義に`fanPostsUrl`を追加

## Testing
- `npm --prefix osarebito-frontend run lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68880c0ede5c832d950ecbb5804c7061