### PR TITLE
Add creator profile feature

### DIFF
--- a/osarebito-backend/app/models.py
+++ b/osarebito-backend/app/models.py
@@ -38,6 +38,18 @@ class CollabProfileUpdate(BaseModel):
     availability: Optional[str] = None
     visibility: Optional[str] = None
 
+class CreatorProfile(BaseModel):
+    skills: Optional[List[str]] = None
+    equipment: Optional[List[str]] = None
+    software: Optional[List[str]] = None
+    visibility: str = "public"
+
+class CreatorProfileUpdate(BaseModel):
+    skills: Optional[List[str]] = None
+    equipment: Optional[List[str]] = None
+    software: Optional[List[str]] = None
+    visibility: Optional[str] = None
+
 class Post(BaseModel):
     id: int
     author_id: str


### PR DESCRIPTION
## Summary
- クリエイタープロフィールのモデルを追加
- 登録時に `creator_profile` フィールドを初期化
- クリエイタープロフィールの取得・更新・検索APIを追加

## Testing
- `python -m py_compile osarebito-backend/app/models.py osarebito-backend/app/routes/users.py`

------
https://chatgpt.com/codex/tasks/task_e_68881e6473a0832d931a4a07cfdd7e2a