### PR TITLE
Add site settings page

### DIFF
--- a/osarebito-frontend/src/app/site-settings/page.tsx
+++ b/osarebito-frontend/src/app/site-settings/page.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+export default function SiteSettings() {
+  return (
+    <div className="max-w-md mx-auto mt-10">
+      <h1 className="text-2xl font-bold mb-4">サイト設定</h1>
+      {/* TODO: settings form */}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/components/Sidebar.tsx
+++ b/osarebito-frontend/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   UserPlusIcon,
   PhotoIcon,
   MagnifyingGlassIcon,
+  Cog6ToothIcon,
 } from '@heroicons/react/24/outline'
 
 export default function Sidebar() {
@@ -30,6 +31,10 @@ export default function Sidebar() {
       <Link href="/profile/search" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
         <MagnifyingGlassIcon className="w-5 h-5" />
         <span>ユーザー検索</span>
+      </Link>
+      <Link href="/site-settings" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <Cog6ToothIcon className="w-5 h-5" />
+        <span>サイト設定</span>
       </Link>
     </nav>
   )


### PR DESCRIPTION
## Summary
- add placeholder site settings page
- link site settings from the sidebar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688820b694b0832dac8d68eaf386073d