### PR TITLE
コミュニティ機能の改善

### DIFF
--- a/osarebito-backend/app/routes/posts.py
+++ b/osarebito-backend/app/routes/posts.py
@@ -127,6 +127,18 @@ def trending_posts():
     return {"posts": result}
 
 
+@router.get("/posts/{post_id}")
+def get_post(post_id: int):
+    posts = load_posts()
+    post = next((p for p in posts if p["id"] == post_id), None)
+    if not post:
+        raise HTTPException(status_code=404, detail="Post not found")
+    item = post.copy()
+    if item.get("anonymous"):
+        item["author_id"] = "匿名"
+    return item
+
+
 @router.get("/posts/by_tag")
 def posts_by_tag(tag: str):
     posts = load_posts()

--- a/osarebito-frontend/src/app/api/posts/[postId]/route.ts
+++ b/osarebito-frontend/src/app/api/posts/[postId]/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getPostUrl } from '@/routes'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function GET(req: NextRequest, { params }: { params: any }) {
+  try {
+    const postId = Array.isArray(params.postId) ? params.postId[0] : params.postId
+    const res = await fetch(getPostUrl(Number(postId)))
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/community/page.tsx
+++ b/osarebito-frontend/src/app/community/page.tsx
@@ -330,17 +330,13 @@ export default function CommunityHome() {
                 )}
                 {p.likes ? p.likes.length : 0}
               </button>
-              <button
+              <Link
+                href={`/community/post/${p.id}`}
                 className="flex items-center gap-1 underline"
-                onClick={() => {
-                  const show = showComments[p.id]
-                  if (!show) loadComments(p.id)
-                  setShowComments((s) => ({ ...s, [p.id]: !show }))
-                }}
               >
                 <ChatBubbleLeftIcon className="w-4 h-4" />
                 {comments[p.id]?.length || 0}
-              </button>
+              </Link>
               <button
                 className="flex items-center gap-1 underline"
                 onClick={() =>
@@ -352,14 +348,20 @@ export default function CommunityHome() {
                   )
                 }
               >
-                <ArrowsRightLeftIcon className="w-4 h-4" />
+                <ArrowsRightLeftIcon
+                  className={`w-4 h-4 ${(
+                    p.retweets || []
+                  ).includes(localStorage.getItem('userId') || '') ? 'text-blue-500' : ''}`}
+                />
                 {p.retweets ? p.retweets.length : 0}
               </button>
               <button
                 className="flex items-center gap-1 underline"
                 onClick={() => handleBookmark(p.id, bookmarks.includes(p.id))}
               >
-                <BookmarkIcon className="w-4 h-4" />
+                <BookmarkIcon
+                  className={`w-4 h-4 ${bookmarks.includes(p.id) ? 'text-green-500' : ''}`}
+                />
               </button>
               <button className="underline" onClick={() => reportPost(p.id)}>
                 通報

--- a/osarebito-frontend/src/app/community/post/[postId]/page.tsx
+++ b/osarebito-frontend/src/app/community/post/[postId]/page.tsx
@@ -1,0 +1,131 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import { useParams } from 'next/navigation'
+import Link from 'next/link'
+import { HeartIcon, ArrowsRightLeftIcon, BookmarkIcon } from '@heroicons/react/24/outline'
+import { HeartIcon as HeartIconSolid } from '@heroicons/react/24/solid'
+
+interface Post {
+  id: number
+  author_id: string
+  content: string
+  created_at: string
+  category?: string | null
+  anonymous?: boolean
+  best_answer_id?: number | null
+  likes?: string[]
+  retweets?: string[]
+}
+
+interface Comment {
+  id: number
+  post_id: number
+  author_id: string
+  content: string
+  created_at: string
+}
+
+export default function PostCommentsPage() {
+  const params = useParams() as { postId: string }
+  const postId = Number(params.postId)
+  const [post, setPost] = useState<Post | null>(null)
+  const [comments, setComments] = useState<Comment[]>([])
+  const [commentText, setCommentText] = useState('')
+  const [bookmarks, setBookmarks] = useState<number[]>([])
+
+  useEffect(() => {
+    axios.get(`/api/posts/${postId}`).then((res) => setPost(res.data))
+    axios.get(`/api/posts/${postId}/comments`).then((res) => setComments(res.data.comments || []))
+    const uid = localStorage.getItem('userId') || ''
+    if (uid) {
+      axios.get(`/api/users/${uid}/bookmarks`).then((res) => {
+        setBookmarks(res.data.posts.map((p: Post) => p.id))
+      })
+    }
+  }, [postId])
+
+  const submitComment = async () => {
+    const author_id = localStorage.getItem('userId') || ''
+    if (!author_id || !commentText) return
+    await axios.post(`/api/posts/${postId}/comments`, { author_id, content: commentText })
+    setCommentText('')
+    const res = await axios.get(`/api/posts/${postId}/comments`)
+    setComments(res.data.comments || [])
+  }
+
+  const handleLike = async (liked: boolean) => {
+    const user_id = localStorage.getItem('userId') || ''
+    if (!user_id) return
+    const url = liked ? `/api/posts/${postId}/unlike` : `/api/posts/${postId}/like`
+    await axios.post(url, { user_id })
+    const res = await axios.get(`/api/posts/${postId}`)
+    setPost(res.data)
+  }
+
+  const handleRetweet = async (rted: boolean) => {
+    const user_id = localStorage.getItem('userId') || ''
+    if (!user_id) return
+    const url = rted ? `/api/posts/${postId}/unretweet` : `/api/posts/${postId}/retweet`
+    await axios.post(url, { user_id })
+    const res = await axios.get(`/api/posts/${postId}`)
+    setPost(res.data)
+  }
+
+  const handleBookmark = async (marked: boolean) => {
+    const user_id = localStorage.getItem('userId') || ''
+    if (!user_id) return
+    const url = marked ? `/api/posts/${postId}/unbookmark` : `/api/posts/${postId}/bookmark`
+    await axios.post(url, { user_id })
+    setBookmarks((b) => (marked ? b.filter((id) => id !== postId) : [...b, postId]))
+  }
+
+  if (!post) return <p className="p-4">Loading...</p>
+
+  const liked = (post.likes || []).includes(localStorage.getItem('userId') || '')
+  const rted = (post.retweets || []).includes(localStorage.getItem('userId') || '')
+  const marked = bookmarks.includes(postId)
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto space-y-4">
+      <Link href="/community" className="underline text-sm">&larr; 戻る</Link>
+      <div className="rounded-lg bg-white p-4 shadow">
+        <div className="text-sm text-gray-600">{post.author_id}</div>
+        {post.category && <div className="text-xs text-pink-600 mb-1">[{post.category}]</div>}
+        <p>{post.content}</p>
+        <div className="mt-2 flex gap-4 text-sm items-center">
+          <button className="flex items-center gap-1 underline" onClick={() => handleLike(liked)}>
+            {liked ? <HeartIconSolid className="w-4 h-4 text-red-500" /> : <HeartIcon className="w-4 h-4" />}
+            {post.likes ? post.likes.length : 0}
+          </button>
+          <button className="flex items-center gap-1 underline" onClick={() => handleRetweet(rted)}>
+            <ArrowsRightLeftIcon className={`w-4 h-4 ${rted ? 'text-blue-500' : ''}`} />
+            {post.retweets ? post.retweets.length : 0}
+          </button>
+          <button className="flex items-center gap-1 underline" onClick={() => handleBookmark(marked)}>
+            <BookmarkIcon className={`w-4 h-4 ${marked ? 'text-green-500' : ''}`} />
+          </button>
+        </div>
+      </div>
+      <div className="space-y-2">
+        {comments.map((c) => (
+          <div key={c.id} className="border-t pt-1 text-sm">
+            <span className="text-gray-600 mr-2">{c.author_id}</span>
+            {c.content}
+          </div>
+        ))}
+        <div className="flex gap-2 mt-2">
+          <input
+            className="rounded flex-1 p-1 text-sm bg-white shadow"
+            value={commentText}
+            onChange={(e) => setCommentText(e.target.value)}
+            placeholder="コメントする"
+          />
+          <button className="bg-pink-500 hover:bg-pink-600 text-white rounded px-2 transition" onClick={submitComment}>
+            送信
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/osarebito-frontend/src/routes.ts
+++ b/osarebito-frontend/src/routes.ts
@@ -47,6 +47,7 @@ export const reportCommentUrl = (commentId: number) => `${BACKEND_URL}/reports/c
 export const trendingPostsUrl = `${BACKEND_URL}/trending_posts`
 export const postsByTagUrl = (tag: string) =>
   `${BACKEND_URL}/posts/by_tag?tag=${encodeURIComponent(tag)}`
+export const getPostUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}`
 export const tutorialTasksUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/tutorial_tasks`
 export const achievementsUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/achievements`
 export const jobsUrl = `${BACKEND_URL}/jobs`


### PR DESCRIPTION
## Summary
- コメントページを追加しコメントボタンから遷移
- リポスト・ブックマークボタンを押すと色が変わるように調整
- 個別投稿取得用のAPIルートをバックエンド/フロントエンドに追加

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68883148d6cc832d9f78cf61f6c63f9c