### PR TITLE
Add report categories

### DIFF
--- a/osarebito-backend/app/models.py
+++ b/osarebito-backend/app/models.py
@@ -94,6 +94,7 @@ class MessageCreate(BaseModel):
 
 class ReportCreate(BaseModel):
     reporter_id: str
+    category: str
     reason: Optional[str] = None
 
 class JobPost(BaseModel):

--- a/osarebito-backend/app/utils.py
+++ b/osarebito-backend/app/utils.py
@@ -18,6 +18,7 @@ async def broadcast(message: dict) -> None:
 
 ALLOWED_ROLES = {"推され人", "推し人", "お仕事人"}
 ROLE_REPORT_POINTS = {"推され人": 1, "推し人": 1, "お仕事人": 1}
+REPORT_CATEGORIES = ["スパム・広告", "迷惑行為", "不適切なコンテンツ", "その他"]
 TUTORIAL_TASKS = ["プロフィールを設定する", "最初の投稿をしてみよう", "他のユーザーをフォローしよう"]
 FIRST_POST_ACHIEVEMENT = "初投稿"
 FIRST_COMMENT_ACHIEVEMENT = "初コメント"

--- a/osarebito-frontend/src/app/api/reports/comment/[commentId]/route.ts
+++ b/osarebito-frontend/src/app/api/reports/comment/[commentId]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { reportCommentUrl } from '@/routes'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function POST(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const commentId = Array.isArray(params.commentId) ? params.commentId[0] : params.commentId
+    const res = await fetch(reportCommentUrl(Number(commentId)), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/api/reports/post/[postId]/route.ts
+++ b/osarebito-frontend/src/app/api/reports/post/[postId]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { reportPostUrl } from '@/routes'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function POST(req: NextRequest, { params }: { params: any }) {
+  try {
+    const data = await req.json()
+    const postId = Array.isArray(params.postId) ? params.postId[0] : params.postId
+    const res = await fetch(reportPostUrl(Number(postId)), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/community/page.tsx
+++ b/osarebito-frontend/src/app/community/page.tsx
@@ -204,16 +204,36 @@ export default function CommunityHome() {
   const reportPost = async (postId: number) => {
     const reporter_id = localStorage.getItem('userId') || ''
     if (!reporter_id) return
-    const reason = window.prompt('通報理由を入力してください') || ''
-    await axios.post(`/api/reports/post/${postId}`, { reporter_id, reason })
+    const cat = window.prompt(
+      '通報カテゴリを番号で選択してください:\n1. スパム・広告\n2. 迷惑行為\n3. 不適切なコンテンツ\n4. その他',
+    )
+    if (!cat) return
+    const categories = ['スパム・広告', '迷惑行為', '不適切なコンテンツ', 'その他']
+    const category = categories[Number(cat) - 1] || 'その他'
+    const reason = window.prompt('詳細な通報内容を入力してください(任意)') || ''
+    await axios.post(`/api/reports/post/${postId}`, {
+      reporter_id,
+      category,
+      reason,
+    })
     alert('通報しました')
   }
 
   const reportComment = async (commentId: number) => {
     const reporter_id = localStorage.getItem('userId') || ''
     if (!reporter_id) return
-    const reason = window.prompt('通報理由を入力してください') || ''
-    await axios.post(`/api/reports/comment/${commentId}`, { reporter_id, reason })
+    const cat = window.prompt(
+      '通報カテゴリを番号で選択してください:\n1. スパム・広告\n2. 迷惑行為\n3. 不適切なコンテンツ\n4. その他',
+    )
+    if (!cat) return
+    const categories = ['スパム・広告', '迷惑行為', '不適切なコンテンツ', 'その他']
+    const category = categories[Number(cat) - 1] || 'その他'
+    const reason = window.prompt('詳細な通報内容を入力してください(任意)') || ''
+    await axios.post(`/api/reports/comment/${commentId}`, {
+      reporter_id,
+      category,
+      reason,
+    })
     alert('通報しました')
   }
 


### PR DESCRIPTION
## Summary
- add `REPORT_CATEGORIES` constant
- allow category in `ReportCreate`
- save selected category when reporting posts/comments
- add API routes for reporting posts and comments on frontend
- prompt users for category selection when reporting

## Testing
- `npm --prefix osarebito-frontend run lint`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688833371f3c832d9a67df37a95f551f