### PR TITLE
Add approval calendar feature

### DIFF
--- a/osarebito-backend/app/crud.py
+++ b/osarebito-backend/app/crud.py
@@ -14,6 +14,7 @@ from .db import (
     materials_table,
     polls_table,
     schedules_table,
+    approval_calendars_table,
 )
 
 
@@ -119,3 +120,11 @@ def load_schedules():
 
 def save_schedules(schedules):
     save_table(schedules_table, schedules, "id")
+
+
+def load_approval_calendars():
+    return load_table(approval_calendars_table)
+
+
+def save_approval_calendars(calendars):
+    save_table(approval_calendars_table, calendars, "id")

--- a/osarebito-backend/app/db.py
+++ b/osarebito-backend/app/db.py
@@ -96,6 +96,13 @@ schedules_table = Table(
     Column("data", JSON, nullable=False),
 )
 
+approval_calendars_table = Table(
+    "approval_calendars",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("data", JSON, nullable=False),
+)
+
 metadata.create_all(engine)
 
 

--- a/osarebito-backend/app/models.py
+++ b/osarebito-backend/app/models.py
@@ -239,3 +239,34 @@ class Schedule(BaseModel):
     events: List[ScheduleEvent]
     template: Optional[str] = "default"
     created_at: str
+
+
+class CalendarSlot(BaseModel):
+    id: Optional[int] = None
+    time: str
+    capacity: int = 1
+    requests: List[str] = []
+    approved: List[str] = []
+
+
+class ApprovalCalendarCreate(BaseModel):
+    author_id: str
+    slots: List[CalendarSlot]
+
+
+class ApprovalCalendar(BaseModel):
+    id: int
+    author_id: str
+    slots: List[CalendarSlot]
+    created_at: str
+
+
+class CalendarRequest(BaseModel):
+    user_id: str
+    slot_id: int
+
+
+class CalendarApproveRequest(BaseModel):
+    user_id: str
+    slot_id: int
+    requester_id: str

--- a/osarebito-frontend/src/app/approval-calendar/page.tsx
+++ b/osarebito-frontend/src/app/approval-calendar/page.tsx
@@ -1,0 +1,137 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import {
+  approvalCalendarsUrl,
+  userCalendarsUrl,
+  calendarRequestUrl,
+  calendarApproveUrl,
+} from '@/routes'
+
+interface Slot {
+  id?: number
+  time: string
+  capacity: number
+  requests?: string[]
+  approved?: string[]
+}
+
+interface Calendar {
+  id: number
+  author_id: string
+  slots: Slot[]
+}
+
+export default function ApprovalCalendarPage() {
+  const [slots, setSlots] = useState<Slot[]>([{ time: '', capacity: 1 }])
+  const [calendars, setCalendars] = useState<Calendar[]>([])
+  const uid = typeof window !== 'undefined' ? localStorage.getItem('userId') || '' : ''
+
+  const load = async () => {
+    if (!uid) return
+    const res = await axios.get(userCalendarsUrl(uid))
+    setCalendars(res.data.calendars || [])
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const addSlot = () => setSlots([...slots, { time: '', capacity: 1 }])
+  const updateSlot = (i: number, field: keyof Slot, value: string | number) => {
+    const copy = [...slots]
+    copy[i] = { ...copy[i], [field]: value }
+    setSlots(copy)
+  }
+  const create = async () => {
+    if (!uid) return
+    await axios.post(approvalCalendarsUrl, { author_id: uid, slots })
+    setSlots([{ time: '', capacity: 1 }])
+    load()
+  }
+
+  const requestSlot = async (cid:number, sid:number) => {
+    if (!uid) return
+    await axios.post(calendarRequestUrl(cid), { user_id: uid, slot_id: sid })
+    load()
+  }
+
+  const approveSlot = async (cid:number, sid:number, requester:string) => {
+    if (!uid) return
+    await axios.post(calendarApproveUrl(cid), {
+      user_id: uid,
+      slot_id: sid,
+      requester_id: requester,
+    })
+    load()
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">承認式カレンダー</h1>
+      <div className="space-y-2 border rounded-lg bg-white p-3 shadow">
+        {slots.map((s, i) => (
+          <div key={i} className="flex gap-2">
+            <input
+              className="border p-1 flex-1"
+              placeholder="日時"
+              value={s.time}
+              onChange={(e) => updateSlot(i, 'time', e.target.value)}
+            />
+            <input
+              className="border p-1 w-20"
+              type="number"
+              value={s.capacity}
+              onChange={(e) => updateSlot(i, 'capacity', Number(e.target.value))}
+            />
+          </div>
+        ))}
+        <button className="bg-gray-200 py-1" onClick={addSlot}>
+          行を追加
+        </button>
+        <button className="bg-pink-500 text-white py-2" onClick={create}>
+          登録
+        </button>
+      </div>
+      <div className="space-y-4">
+        {calendars.map((c) => (
+          <div key={c.id} className="border rounded-lg bg-white p-4 shadow space-y-2">
+            <div className="font-semibold">{c.author_id}</div>
+            {c.slots.map((s) => (
+              <div key={s.id} className="border p-2 rounded">
+                <div>
+                  {s.time} 定員{s.capacity}
+                </div>
+                <div className="text-sm">承認済み: {s.approved?.join(', ') || 'なし'}</div>
+                {uid === c.author_id ? (
+                  <div className="space-y-1">
+                    {s.requests && s.requests.length > 0 ? (
+                      s.requests.map((r) => (
+                        <button
+                          key={r}
+                          className="text-xs underline text-pink-500 mr-2"
+                          onClick={() => approveSlot(c.id, s.id || 0, r)}
+                        >
+                          {r}を承認
+                        </button>
+                      ))
+                    ) : (
+                      <div className="text-xs">リクエストなし</div>
+                    )}
+                  </div>
+                ) : (
+                  <button
+                    className="text-xs underline text-pink-500"
+                    onClick={() => requestSlot(c.id, s.id || 0)}
+                  >
+                    予約リクエスト
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/osarebito-frontend/src/components/Sidebar.tsx
+++ b/osarebito-frontend/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   PhotoIcon,
   MagnifyingGlassIcon,
   Cog6ToothIcon,
+  CalendarDaysIcon,
 } from '@heroicons/react/24/outline'
 
 export default function Sidebar() {
@@ -31,6 +32,10 @@ export default function Sidebar() {
       <Link href="/profile/search" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
         <MagnifyingGlassIcon className="w-5 h-5" />
         <span>ユーザー検索</span>
+      </Link>
+      <Link href="/approval-calendar" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <CalendarDaysIcon className="w-5 h-5" />
+        <span>承認式カレンダー</span>
       </Link>
       <Link href="/site-settings" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
         <Cog6ToothIcon className="w-5 h-5" />

--- a/osarebito-frontend/src/routes.ts
+++ b/osarebito-frontend/src/routes.ts
@@ -61,3 +61,7 @@ export const saveMaterialUrl = (id: number) => `${BACKEND_URL}/materials/${id}/s
 export const unsaveMaterialUrl = (id: number) => `${BACKEND_URL}/materials/${id}/unsave`
 export const schedulesUrl = `${BACKEND_URL}/schedules`
 export const scheduleImageUrl = (id: number) => `${BACKEND_URL}/schedules/${id}/image`
+export const approvalCalendarsUrl = `${BACKEND_URL}/approval_calendars`
+export const userCalendarsUrl = (userId: string) => `${BACKEND_URL}/approval_calendars/${userId}`
+export const calendarRequestUrl = (id: number) => `${BACKEND_URL}/approval_calendars/${id}/request`
+export const calendarApproveUrl = (id: number) => `${BACKEND_URL}/approval_calendars/${id}/approve`


### PR DESCRIPTION
## Summary
- 承認式カレンダー機能を実装
- カレンダーの新規登録、予約申請、承認を行うエンドポイントを追加
- 左メニューに「承認式カレンダー」を追加
- フロントにカレンダー管理画面を作成

## Testing
- `npm --prefix osarebito-frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_68883624f778832daeafa454334b2da8