### PR TITLE
Add placeholder YouTube analysis feature

### DIFF
--- a/osarebito-frontend/src/app/youtube-analysis/page.tsx
+++ b/osarebito-frontend/src/app/youtube-analysis/page.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+export default function YoutubeAnalysis() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Youtube盛り上がり分析</h1>
+      {/* TODO: implement Youtube analytics */}
+    </div>
+  )
+}

--- a/osarebito-frontend/src/components/Sidebar.tsx
+++ b/osarebito-frontend/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   UserPlusIcon,
   PhotoIcon,
   MagnifyingGlassIcon,
+  ChartBarIcon,
   Cog6ToothIcon,
   CalendarDaysIcon,
 } from '@heroicons/react/24/outline'
@@ -36,6 +37,10 @@ export default function Sidebar() {
       <Link href="/approval-calendar" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
         <CalendarDaysIcon className="w-5 h-5" />
         <span>承認式カレンダー</span>
+      </Link>
+      <Link href="/youtube-analysis" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <ChartBarIcon className="w-5 h-5" />
+        <span>YouTube分析</span>
       </Link>
       <Link href="/site-settings" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
         <Cog6ToothIcon className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- add a minimal YouTube analysis page
- link the new page from the sidebar using a chart icon

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68883863cd60832da772018773c35988