### PR TITLE
コミュニティ機能の改善

### DIFF
--- a/osarebito-backend/app/routes/users.py
+++ b/osarebito-backend/app/routes/users.py
@@ -243,6 +243,23 @@ def list_bookmarks(user_id: str):
     return {"posts": result}
 
 
+@router.get("/users/{user_id}/retweets")
+def list_retweets(user_id: str):
+    users = load_users()
+    if not any(u["user_id"] == user_id for u in users):
+        raise HTTPException(status_code=404, detail="User not found")
+    posts = load_posts()
+    result = []
+    for p in posts:
+        if user_id in p.get("retweets", []):
+            item = p.copy()
+            if item.get("anonymous"):
+                item["author_id"] = "匿名"
+            result.append(item)
+    result.sort(key=lambda x: x["id"], reverse=True)
+    return {"posts": result}
+
+
 @router.get("/users/search")
 def search_users(query: str):
     users = load_users()

--- a/osarebito-frontend/src/app/community/bookmarks/page.tsx
+++ b/osarebito-frontend/src/app/community/bookmarks/page.tsx
@@ -2,6 +2,13 @@
 import { useEffect, useState } from 'react'
 import axios from 'axios'
 import Link from 'next/link'
+import {
+  HeartIcon,
+  ArrowsRightLeftIcon,
+  BookmarkIcon,
+} from '@heroicons/react/24/outline'
+import { HeartIcon as HeartIconSolid } from '@heroicons/react/24/solid'
+import ReportModal from '../../../components/ReportModal'
 
 interface Post {
   id: number
@@ -13,34 +20,118 @@ interface Post {
 
 export default function CommunityBookmarks() {
   const [posts, setPosts] = useState<Post[]>([])
+  const [bookmarks, setBookmarks] = useState<number[]>([])
+  const [reportTarget, setReportTarget] = useState<
+    | { type: 'post'; id: number }
+    | { type: 'comment'; id: number }
+    | null
+  >(null)
 
   useEffect(() => {
     const uid = localStorage.getItem('userId') || ''
     if (!uid) return
     axios.get(`/api/users/${uid}/bookmarks`).then((res) => {
-      setPosts(res.data.posts || [])
+      const list = res.data.posts || []
+      setPosts(list)
+      setBookmarks(list.map((p: Post) => p.id))
     })
   }, [])
+
+  const handleLike = async (postId: number, liked: boolean) => {
+    const user_id = localStorage.getItem('userId') || ''
+    if (!user_id) return
+    const url = liked
+      ? `/api/posts/${postId}/unlike`
+      : `/api/posts/${postId}/like`
+    await axios.post(url, { user_id })
+    setPosts((prev) =>
+      prev.map((p) => {
+        if (p.id !== postId) return p
+        const list = p.likes || []
+        return {
+          ...p,
+          likes: liked ? list.filter((v) => v !== user_id) : [...list, user_id],
+        }
+      }),
+    )
+  }
+
+  const handleRetweet = async (postId: number, rted: boolean) => {
+    const user_id = localStorage.getItem('userId') || ''
+    if (!user_id) return
+    const url = rted
+      ? `/api/posts/${postId}/unretweet`
+      : `/api/posts/${postId}/retweet`
+    await axios.post(url, { user_id })
+    setPosts((prev) =>
+      prev.map((p) =>
+        p.id === postId
+          ? {
+              ...p,
+              retweets: rted
+                ? (p.retweets || []).filter((v) => v !== user_id)
+                : [...(p.retweets || []), user_id],
+            }
+          : p,
+      ),
+    )
+  }
+
+  const handleBookmark = async (postId: number, marked: boolean) => {
+    const user_id = localStorage.getItem('userId') || ''
+    if (!user_id) return
+    const url = marked
+      ? `/api/posts/${postId}/unbookmark`
+      : `/api/posts/${postId}/bookmark`
+    await axios.post(url, { user_id })
+    setBookmarks((b) => (marked ? b.filter((id) => id !== postId) : [...b, postId]))
+  }
+
+  const openReport = (id: number) => {
+    setReportTarget({ type: 'post', id })
+  }
 
   return (
     <div>
       <h1 className="text-xl font-bold mb-4">ブックマーク一覧</h1>
-      {posts.map((p) => (
-        <div key={p.id} className="border rounded-lg bg-white p-4 shadow mb-3">
-          <div className="text-sm text-gray-600">{p.author_id}</div>
-          {p.category && (
-            <div className="text-xs text-pink-600 mb-1">[{p.category}]</div>
-          )}
-          <p>{p.content}</p>
-          <Link
-            href={`/community#post-${p.id}`}
-            className="text-xs text-pink-500 underline"
-          >
-            元の投稿へ
-          </Link>
-        </div>
-      ))}
+      {posts.map((p) => {
+        const liked = (p.likes || []).includes(localStorage.getItem('userId') || '')
+        const rted = (p.retweets || []).includes(localStorage.getItem('userId') || '')
+        const marked = bookmarks.includes(p.id)
+        return (
+          <div key={p.id} className="border rounded-lg bg-white p-4 shadow mb-3">
+            <div className="text-sm text-gray-600">{p.author_id}</div>
+            {p.category && (
+              <div className="text-xs text-pink-600 mb-1">[{p.category}]</div>
+            )}
+            <p>{p.content}</p>
+            <div className="mt-2 flex gap-4 text-sm items-center">
+              <button className="flex items-center gap-1 underline" onClick={() => handleLike(p.id, liked)}>
+                {liked ? <HeartIconSolid className="w-4 h-4 text-red-500" /> : <HeartIcon className="w-4 h-4" />}
+                {p.likes ? p.likes.length : 0}
+              </button>
+              <button className="flex items-center gap-1 underline" onClick={() => handleRetweet(p.id, rted)}>
+                <ArrowsRightLeftIcon className={`w-4 h-4 ${rted ? 'text-blue-500' : ''}`} />
+                {p.retweets ? p.retweets.length : 0}
+              </button>
+              <button className="flex items-center gap-1 underline" onClick={() => handleBookmark(p.id, marked)}>
+                <BookmarkIcon className={`w-4 h-4 ${marked ? 'text-green-500' : ''}`} />
+              </button>
+              <button className="underline text-xs" onClick={() => openReport(p.id)}>
+                通報
+              </button>
+            </div>
+          </div>
+        )
+      })}
       {posts.length === 0 && <p>ブックマークはありません。</p>}
+      {reportTarget && (
+        <ReportModal
+          targetType={reportTarget.type}
+          targetId={reportTarget.id}
+          onClose={() => setReportTarget(null)}
+        />
+      )}
     </div>
   )
 }

--- a/osarebito-frontend/src/app/community/mypage/page.tsx
+++ b/osarebito-frontend/src/app/community/mypage/page.tsx
@@ -1,0 +1,59 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import Link from 'next/link'
+
+interface Post {
+  id: number
+  author_id: string
+  content: string
+  created_at: string
+  category?: string | null
+}
+
+export default function CommunityMyPage() {
+  const [posts, setPosts] = useState<Post[]>([])
+  const [retweets, setRetweets] = useState<Post[]>([])
+
+  useEffect(() => {
+    const uid = localStorage.getItem('userId') || ''
+    if (!uid) return
+    axios.get(`/api/posts?feed=user&user_id=${uid}`).then((res) => {
+      setPosts(res.data.posts || [])
+    })
+    axios.get(`/api/users/${uid}/retweets`).then((res) => {
+      setRetweets(res.data.posts || [])
+    })
+  }, [])
+
+  const Card = ({ p }: { p: Post }) => (
+    <div key={p.id} className="rounded-lg bg-white p-4 shadow mb-3">
+      <div className="text-sm text-gray-600">{p.author_id}</div>
+      {p.category && <div className="text-xs text-pink-600 mb-1">[{p.category}]</div>}
+      <p>{p.content}</p>
+      <Link href={`/community/post/${p.id}`} className="text-xs text-pink-500 underline">
+        詳細
+      </Link>
+    </div>
+  )
+
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-xl font-bold">マイページ</h1>
+      <section>
+        <h2 className="font-semibold mb-2">自分の投稿</h2>
+        {posts.map((p) => (
+          <Card key={p.id} p={p} />
+        ))}
+        {posts.length === 0 && <p>投稿がありません。</p>}
+      </section>
+      <section>
+        <h2 className="font-semibold mb-2">リポストした投稿</h2>
+        {retweets.map((p) => (
+          <Card key={p.id} p={p} />
+        ))}
+        {retweets.length === 0 && <p>リポストはありません。</p>}
+      </section>
+    </div>
+  )
+}

--- a/osarebito-frontend/src/app/community/post/[postId]/page.tsx
+++ b/osarebito-frontend/src/app/community/post/[postId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { HeartIcon, ArrowsRightLeftIcon, BookmarkIcon } from '@heroicons/react/24/outline'
 import { HeartIcon as HeartIconSolid } from '@heroicons/react/24/solid'
+import ReportModal from '../../../components/ReportModal'
 
 interface Post {
   id: number
@@ -33,6 +34,11 @@ export default function PostCommentsPage() {
   const [comments, setComments] = useState<Comment[]>([])
   const [commentText, setCommentText] = useState('')
   const [bookmarks, setBookmarks] = useState<number[]>([])
+  const [reportTarget, setReportTarget] = useState<
+    | { type: 'post'; id: number }
+    | { type: 'comment'; id: number }
+    | null
+  >(null)
 
   useEffect(() => {
     axios.get(`/api/posts/${postId}`).then((res) => setPost(res.data))
@@ -105,13 +111,22 @@ export default function PostCommentsPage() {
           <button className="flex items-center gap-1 underline" onClick={() => handleBookmark(marked)}>
             <BookmarkIcon className={`w-4 h-4 ${marked ? 'text-green-500' : ''}`} />
           </button>
+          <button className="underline text-sm" onClick={() => setReportTarget({ type: 'post', id: postId })}>
+            通報
+          </button>
         </div>
       </div>
       <div className="space-y-2">
         {comments.map((c) => (
-          <div key={c.id} className="border-t pt-1 text-sm">
+          <div key={c.id} className="rounded-lg bg-white p-2 shadow text-sm">
             <span className="text-gray-600 mr-2">{c.author_id}</span>
             {c.content}
+            <button
+              className="ml-2 text-xs underline"
+              onClick={() => setReportTarget({ type: 'comment', id: c.id })}
+            >
+              通報
+            </button>
           </div>
         ))}
         <div className="flex gap-2 mt-2">
@@ -126,6 +141,13 @@ export default function PostCommentsPage() {
           </button>
         </div>
       </div>
+      {reportTarget && (
+        <ReportModal
+          targetType={reportTarget.type}
+          targetId={reportTarget.id}
+          onClose={() => setReportTarget(null)}
+        />
+      )}
     </div>
   )
 }

--- a/osarebito-frontend/src/components/CommunitySidebar.tsx
+++ b/osarebito-frontend/src/components/CommunitySidebar.tsx
@@ -54,6 +54,10 @@ export default function CommunitySidebar() {
         <BookmarkIcon className="w-5 h-5" />
         <span>ブックマーク</span>
       </Link>
+      <Link href="/community/mypage" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <UserGroupIcon className="w-5 h-5" />
+        <span>マイページ</span>
+      </Link>
       <Link href="/community/jobs" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
         <BriefcaseIcon className="w-5 h-5" />
         <span>依頼掲示板</span>

--- a/osarebito-frontend/src/components/ReportModal.tsx
+++ b/osarebito-frontend/src/components/ReportModal.tsx
@@ -1,0 +1,63 @@
+'use client'
+import { useState } from 'react'
+import axios from 'axios'
+import { reportPostUrl, reportCommentUrl } from '@/routes'
+
+interface Props {
+  targetType: 'post' | 'comment'
+  targetId: number
+  onClose: () => void
+}
+
+export default function ReportModal({ targetType, targetId, onClose }: Props) {
+  const [category, setCategory] = useState('スパム・広告')
+  const [reason, setReason] = useState('')
+
+  const submit = async () => {
+    const reporter_id = localStorage.getItem('userId') || ''
+    if (!reporter_id) return
+    const url =
+      targetType === 'post'
+        ? reportPostUrl(targetId)
+        : reportCommentUrl(targetId)
+    await axios.post(url, { reporter_id, category, reason })
+    onClose()
+    alert('通報しました')
+  }
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white p-4 rounded shadow w-72">
+        <h3 className="font-bold mb-2">通報</h3>
+        <select
+          className="border rounded w-full p-1 mb-2"
+          value={category}
+          onChange={(e) => setCategory(e.target.value)}
+        >
+          <option value="スパム・広告">スパム・広告</option>
+          <option value="迷惑行為">迷惑行為</option>
+          <option value="不適切なコンテンツ">不適切なコンテンツ</option>
+          <option value="その他">その他</option>
+        </select>
+        <textarea
+          className="border rounded w-full p-1 mb-2"
+          rows={3}
+          placeholder="詳細(任意)"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+        />
+        <div className="flex justify-end gap-2">
+          <button className="px-2 py-1 text-sm" onClick={onClose}>
+            キャンセル
+          </button>
+          <button
+            className="bg-pink-500 hover:bg-pink-600 text-white px-3 py-1 rounded text-sm"
+            onClick={submit}
+          >
+            送信
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/osarebito-frontend/src/routes.ts
+++ b/osarebito-frontend/src/routes.ts
@@ -36,6 +36,7 @@ export const updatesWsUrl = BACKEND_URL.replace(/^http/, 'ws') + '/ws/updates'
 export const bookmarkPostUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}/bookmark`
 export const unbookmarkPostUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}/unbookmark`
 export const userBookmarksUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/bookmarks`
+export const userRetweetsUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/retweets`
 export const retweetPostUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}/retweet`
 export const unretweetPostUrl = (postId: number) => `${BACKEND_URL}/posts/${postId}/unretweet`
 export const sendMessageUrl = `${BACKEND_URL}/messages`


### PR DESCRIPTION
## Summary
- いいね等のモダンUIを実装する ReportModal を追加
- コミュニティページのコメントをカード表示に変更
- 通報UIをモーダル化
- ブックマーク一覧をタイムラインと同じ表示に統一
- マイページを追加し投稿・リポストを確認可能
- リポスト取得用の API 追加

## Testing
- `npm --prefix osarebito-frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_68883cc44d70832da68b4b7d2c463738