### PR TITLE
Improve community UI and anonymous mode

### DIFF
--- a/osarebito-backend/app/routes/posts.py
+++ b/osarebito-backend/app/routes/posts.py
@@ -67,7 +67,12 @@ async def create_post(post: PostCreate):
 
 
 @router.get("/posts")
-def list_posts(feed: str | None = None, user_id: str | None = None, category: str | None = None):
+def list_posts(
+    feed: str | None = None,
+    user_id: str | None = None,
+    category: str | None = None,
+    anonymous: bool | None = None,
+):
     posts = load_posts()
     users = load_users()
     blocked_me = set()
@@ -79,6 +84,8 @@ def list_posts(feed: str | None = None, user_id: str | None = None, category: st
             blocked_by_me = set(me.get("blocks", []))
     if category:
         posts = [p for p in posts if p.get("category") == category]
+    if anonymous is not None:
+        posts = [p for p in posts if bool(p.get("anonymous")) == anonymous]
     if feed == "following" and user_id:
         me = next((u for u in users if u["user_id"] == user_id), None)
         if not me:
@@ -95,6 +102,7 @@ def list_posts(feed: str | None = None, user_id: str | None = None, category: st
         if item.get("anonymous"):
             item["author_id"] = "匿名"
         result.append(item)
+    result.sort(key=lambda x: x.get("created_at", ""), reverse=True)
     return {"posts": result}
 
 

--- a/osarebito-frontend/src/app/community/post/[postId]/page.tsx
+++ b/osarebito-frontend/src/app/community/post/[postId]/page.tsx
@@ -148,6 +148,9 @@ export default function PostCommentsPage() {
             通報
           </button>
         </div>
+        <div className="text-right text-xs text-gray-500 mt-1">
+          {new Date(post.created_at).toLocaleString()}
+        </div>
       </div>
       <div className="space-y-2">
         {comments.map((c) => (

--- a/osarebito-frontend/src/components/CommunitySidebar.tsx
+++ b/osarebito-frontend/src/components/CommunitySidebar.tsx
@@ -16,6 +16,7 @@ import { useEffect, useState } from 'react'
 
 export default function CommunitySidebar() {
   const [showTutorial, setShowTutorial] = useState(false)
+  const [anonMode, setAnonMode] = useState(false)
 
   useEffect(() => {
     const uid = localStorage.getItem('userId') || ''
@@ -25,6 +26,7 @@ export default function CommunitySidebar() {
       .then((data) => {
         setShowTutorial((data.tasks || []).length > 0)
       })
+    setAnonMode(localStorage.getItem('anonymousMode') === '1')
   }, [])
 
   return (
@@ -80,6 +82,21 @@ export default function CommunitySidebar() {
           <span>チュートリアル</span>
         </Link>
       )}
+      <button
+        className="flex items-center gap-2 text-pink-700 hover:text-pink-900"
+        onClick={() => {
+          if (anonMode) {
+            localStorage.removeItem('anonymousMode')
+          } else {
+            localStorage.setItem('anonymousMode', '1')
+          }
+          setAnonMode(!anonMode)
+          location.href = '/community'
+        }}
+      >
+        <UserGroupIcon className="w-5 h-5" />
+        <span>{anonMode ? '通常モード' : '匿名モード'}</span>
+      </button>
     </nav>
   )
 }


### PR DESCRIPTION
## Summary
- add anonymous-only filter on backend and sort by creation time
- rework post form UI with option buttons
- support anonymous mode toggle in CommunitySidebar
- show timestamps on posts
- allow tag-based search in community page

## Testing
- `npm --prefix osarebito-frontend run lint`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688880a054cc832db2ff371a5dd4e6b6