### PR TITLE
Add image upload support and comment page layout

### DIFF
--- a/osarebito-backend/app/models.py
+++ b/osarebito-backend/app/models.py
@@ -60,6 +60,7 @@ class Post(BaseModel):
     best_answer_id: Optional[int] = None
     likes: List[str] = []
     retweets: List[str] = []
+    image: Optional[str] = None
     created_at: str
 
 class PostCreate(BaseModel):
@@ -68,6 +69,7 @@ class PostCreate(BaseModel):
     tags: Optional[List[str]] = None
     category: Optional[str] = None
     anonymous: bool = False
+    image: Optional[str] = None
 
 class Comment(BaseModel):
     id: int

--- a/osarebito-backend/app/routes/posts.py
+++ b/osarebito-backend/app/routes/posts.py
@@ -55,6 +55,7 @@ async def create_post(post: PostCreate):
         "best_answer_id": None,
         "likes": [],
         "retweets": [],
+        "image": post.image,
         "created_at": datetime.utcnow().isoformat(),
     }
     posts.append(item)

--- a/osarebito-frontend/src/app/community/bookmarks/page.tsx
+++ b/osarebito-frontend/src/app/community/bookmarks/page.tsx
@@ -17,6 +17,7 @@ interface Post {
   category?: string | null
   likes?: string[]
   retweets?: string[]
+  image?: string | null
 }
 
 export default function CommunityBookmarks() {
@@ -106,6 +107,9 @@ export default function CommunityBookmarks() {
               <div className="text-xs text-pink-600 mb-1">[{p.category}]</div>
             )}
             <p>{p.content}</p>
+            {p.image && (
+              <img src={p.image} alt="post image" className="max-h-60 mt-2" />
+            )}
             <div className="mt-2 flex gap-4 text-sm items-center">
               <button className="flex items-center gap-1 underline" onClick={() => handleLike(p.id, liked)}>
                 {liked ? <HeartIconSolid className="w-4 h-4 text-red-500" /> : <HeartIcon className="w-4 h-4" />}

--- a/osarebito-frontend/src/app/community/mypage/page.tsx
+++ b/osarebito-frontend/src/app/community/mypage/page.tsx
@@ -9,6 +9,7 @@ interface Post {
   content: string
   created_at: string
   category?: string | null
+  image?: string | null
 }
 
 export default function CommunityMyPage() {
@@ -31,6 +32,7 @@ export default function CommunityMyPage() {
       <div className="text-sm text-gray-600">{p.author_id}</div>
       {p.category && <div className="text-xs text-pink-600 mb-1">[{p.category}]</div>}
       <p>{p.content}</p>
+      {p.image && <img src={p.image} alt="post image" className="max-h-60 mt-2" />}
       <Link href={`/community/post/${p.id}`} className="text-xs text-pink-500 underline">
         詳細
       </Link>

--- a/osarebito-frontend/src/app/community/tag/[tag]/page.tsx
+++ b/osarebito-frontend/src/app/community/tag/[tag]/page.tsx
@@ -11,6 +11,7 @@ interface Post {
   category?: string | null
   likes?: string[]
   retweets?: string[]
+  image?: string | null
 }
 
 export default function TagPostsPage() {
@@ -34,6 +35,9 @@ export default function TagPostsPage() {
             <div className="text-xs text-pink-600 mb-1">[{p.category}]</div>
           )}
           <p>{p.content}</p>
+          {p.image && (
+            <img src={p.image} alt="post image" className="max-h-60 mt-2" />
+          )}
           <div className="text-xs text-gray-600 mt-1 flex items-center gap-4">
             <span className="flex items-center gap-1">
               <HeartIcon className="w-4 h-4" />

--- a/osarebito-frontend/src/app/community/trends/page.tsx
+++ b/osarebito-frontend/src/app/community/trends/page.tsx
@@ -15,6 +15,7 @@ interface Post {
   content: string
   likes?: string[]
   retweets?: string[]
+  image?: string | null
 }
 
 export default function CommunityTrends() {
@@ -47,8 +48,11 @@ export default function CommunityTrends() {
         <h2 className="font-semibold mb-2">人気投稿</h2>
         {posts.map((p) => (
           <div key={p.id} className="border rounded-lg bg-white p-3 mb-3 shadow">
-            <div className="text-sm text-gray-600">{p.author_id}</div>
+           <div className="text-sm text-gray-600">{p.author_id}</div>
             <p>{p.content}</p>
+            {p.image && (
+              <img src={p.image} alt="post image" className="max-h-60 mt-2" />
+            )}
             <div className="text-xs text-gray-600 mt-1 flex items-center gap-4">
               <span className="flex items-center gap-1">
                 <HeartIcon className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- allow posts to include optional `image` field
- store image when creating posts
- support image uploads from community home
- filter posts by anonymous mode
- hide comments in feed and improve comment page layout
- display post images on pages

## Testing
- `npm --prefix osarebito-frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_6888cc3b96f0832d81b0776fc83ad6d9