### PR TITLE
Adjust anonymous mode logic

### DIFF
--- a/osarebito-frontend/src/app/community/bookmarks/page.tsx
+++ b/osarebito-frontend/src/app/community/bookmarks/page.tsx
@@ -18,6 +18,7 @@ interface Post {
   likes?: string[]
   retweets?: string[]
   image?: string | null
+  anonymous?: boolean
 }
 
 export default function CommunityBookmarks() {
@@ -34,8 +35,10 @@ export default function CommunityBookmarks() {
     if (!uid) return
     axios.get(`/api/users/${uid}/bookmarks`).then((res) => {
       const list = res.data.posts || []
-      setPosts(list)
-      setBookmarks(list.map((p: Post) => p.id))
+      const anon = localStorage.getItem('anonymousMode') === '1'
+      const filtered = list.filter((p: Post) => (anon ? p.anonymous : !p.anonymous))
+      setPosts(filtered)
+      setBookmarks(filtered.map((p: Post) => p.id))
     })
   }, [])
 

--- a/osarebito-frontend/src/app/community/mypage/page.tsx
+++ b/osarebito-frontend/src/app/community/mypage/page.tsx
@@ -10,6 +10,7 @@ interface Post {
   created_at: string
   category?: string | null
   image?: string | null
+  anonymous?: boolean
 }
 
 export default function CommunityMyPage() {
@@ -19,11 +20,14 @@ export default function CommunityMyPage() {
   useEffect(() => {
     const uid = localStorage.getItem('userId') || ''
     if (!uid) return
+    const anon = localStorage.getItem('anonymousMode') === '1'
     axios.get(`/api/posts?feed=user&user_id=${uid}`).then((res) => {
-      setPosts(res.data.posts || [])
+      const list = res.data.posts || []
+      setPosts(list.filter((p: Post) => (anon ? p.anonymous : !p.anonymous)))
     })
     axios.get(`/api/users/${uid}/retweets`).then((res) => {
-      setRetweets(res.data.posts || [])
+      const list = res.data.posts || []
+      setRetweets(list.filter((p: Post) => (anon ? p.anonymous : !p.anonymous)))
     })
   }, [])
 

--- a/osarebito-frontend/src/app/community/page.tsx
+++ b/osarebito-frontend/src/app/community/page.tsx
@@ -12,7 +12,6 @@ import {
   ChartBarIcon,
   CalendarDaysIcon,
   TagIcon,
-  UserIcon,
 } from '@heroicons/react/24/outline'
 import { HeartIcon as HeartIconSolid } from '@heroicons/react/24/solid'
 import ReportModal from '../../components/ReportModal'
@@ -55,7 +54,6 @@ export default function CommunityHome() {
   const [tags, setTags] = useState<{ name: string; count: number }[]>([])
   const [newPost, setNewPost] = useState('')
   const [newCategory, setNewCategory] = useState('')
-  const [anonymous, setAnonymous] = useState(false)
   const [showCategoryModal, setShowCategoryModal] = useState(false)
   const [showPollModal, setShowPollModal] = useState(false)
   const [showScheduleModal, setShowScheduleModal] = useState(false)
@@ -138,12 +136,11 @@ export default function CommunityHome() {
       author_id,
       content: newPost,
       category: newCategory || null,
-      anonymous,
+      anonymous: localStorage.getItem('anonymousMode') === '1',
       image: newImage,
     })
     setNewPost('')
     setNewCategory('')
-    setAnonymous(false)
     setNewImage(null)
     fetchPosts(feed)
   }
@@ -318,12 +315,6 @@ export default function CommunityHome() {
             </button>
             <button onClick={() => setShowCategoryModal(true)} className="p-1 hover:bg-pink-100 rounded">
               <TagIcon className="w-5 h-5" />
-            </button>
-            <button
-              onClick={() => setAnonymous((a) => !a)}
-              className={`p-1 hover:bg-pink-100 rounded ${anonymous ? 'text-pink-500' : ''}`}
-            >
-              <UserIcon className="w-5 h-5" />
             </button>
             <button className="ml-auto bg-pink-500 hover:bg-pink-600 text-white rounded px-4 transition" onClick={submitPost}>
               投稿

--- a/osarebito-frontend/src/app/community/tag/[tag]/page.tsx
+++ b/osarebito-frontend/src/app/community/tag/[tag]/page.tsx
@@ -12,6 +12,7 @@ interface Post {
   likes?: string[]
   retweets?: string[]
   image?: string | null
+  anonymous?: boolean
 }
 
 export default function TagPostsPage() {
@@ -21,7 +22,9 @@ export default function TagPostsPage() {
 
   useEffect(() => {
     axios.get(`/api/posts/tag/${encodeURIComponent(tag)}`).then((res) => {
-      setPosts(res.data.posts || [])
+      const list = res.data.posts || []
+      const anon = localStorage.getItem('anonymousMode') === '1'
+      setPosts(list.filter((p: Post) => (anon ? p.anonymous : !p.anonymous)))
     })
   }, [tag])
 

--- a/osarebito-frontend/src/app/community/trends/page.tsx
+++ b/osarebito-frontend/src/app/community/trends/page.tsx
@@ -16,6 +16,7 @@ interface Post {
   likes?: string[]
   retweets?: string[]
   image?: string | null
+  anonymous?: boolean
 }
 
 export default function CommunityTrends() {
@@ -24,7 +25,11 @@ export default function CommunityTrends() {
 
   useEffect(() => {
     axios.get('/api/popular_tags').then((res) => setTags(res.data || []))
-    axios.get(trendingPostsUrl).then((res) => setPosts(res.data.posts || []))
+    axios.get(trendingPostsUrl).then((res) => {
+      const list = res.data.posts || []
+      const anon = localStorage.getItem('anonymousMode') === '1'
+      setPosts(list.filter((p: Post) => (anon ? p.anonymous : !p.anonymous)))
+    })
   }, [])
 
   return (


### PR DESCRIPTION
## Summary
- remove manual anonymous toggle for new posts
- auto-set anonymity based on anonymous mode
- filter posts by anonymous mode across community pages

## Testing
- `npm --prefix osarebito-frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_6889649978e0832da65beaef8a56d6ad