### PR TITLE
Improve reaction performance

### DIFF
--- a/osarebito-backend/app/crud.py
+++ b/osarebito-backend/app/crud.py
@@ -1,6 +1,8 @@
 from .db import (
     load_table,
     save_table,
+    get_item,
+    update_item,
     users_table,
     posts_table,
     comments_table,
@@ -32,6 +34,14 @@ def load_posts():
 
 def save_posts(posts):
     save_table(posts_table, posts, "id")
+
+
+def get_post(post_id: int):
+    return get_item(posts_table, "id", post_id)
+
+
+def update_post(post: dict):
+    update_item(posts_table, "id", post["id"], post)
 
 
 def load_comments():

--- a/osarebito-backend/app/db.py
+++ b/osarebito-backend/app/db.py
@@ -1,5 +1,17 @@
 import os
-from sqlalchemy import create_engine, MetaData, Table, Column, Integer, String, JSON, select, insert, delete
+from sqlalchemy import (
+    create_engine,
+    MetaData,
+    Table,
+    Column,
+    Integer,
+    String,
+    JSON,
+    select,
+    insert,
+    delete,
+    update,
+)
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///osarebito.db")
 engine = create_engine(DATABASE_URL)
@@ -117,4 +129,19 @@ def save_table(table, items, key):
         records = [{key: item[key], "data": item} for item in items]
         if records:
             conn.execute(insert(table), records)
+
+
+def get_item(table, key_field, key_value):
+    """Return a single item from a table by key or None."""
+    stmt = select(table.c.data).where(table.c[key_field] == key_value)
+    with engine.connect() as conn:
+        row = conn.execute(stmt).fetchone()
+        return row.data if row else None
+
+
+def update_item(table, key_field, key_value, item):
+    """Update a single item in a table."""
+    stmt = update(table).where(table.c[key_field] == key_value).values(data=item)
+    with engine.begin() as conn:
+        conn.execute(stmt)
 

--- a/osarebito-backend/app/routes/posts.py
+++ b/osarebito-backend/app/routes/posts.py
@@ -15,6 +15,8 @@ from ..crud import (
     save_users,
     load_posts,
     save_posts,
+    get_post,
+    update_post,
     load_comments,
     save_comments,
     load_reports,
@@ -165,56 +167,52 @@ def posts_by_tag(tag: str):
 
 @router.post("/posts/{post_id}/like")
 async def like_post(post_id: int, data: LikeRequest):
-    posts = load_posts()
-    post = next((p for p in posts if p["id"] == post_id), None)
+    post = get_post(post_id)
     if not post:
         raise HTTPException(status_code=404, detail="Post not found")
     likes = post.setdefault("likes", [])
     if data.user_id not in likes:
         likes.append(data.user_id)
-        save_posts(posts)
+        update_post(post)
         await broadcast({"type": "like", "post_id": post_id, "likes": likes})
     return {"likes": len(likes)}
 
 
 @router.post("/posts/{post_id}/unlike")
 async def unlike_post(post_id: int, data: LikeRequest):
-    posts = load_posts()
-    post = next((p for p in posts if p["id"] == post_id), None)
+    post = get_post(post_id)
     if not post:
         raise HTTPException(status_code=404, detail="Post not found")
     likes = post.setdefault("likes", [])
     if data.user_id in likes:
         likes.remove(data.user_id)
-        save_posts(posts)
+        update_post(post)
         await broadcast({"type": "like", "post_id": post_id, "likes": likes})
     return {"likes": len(likes)}
 
 
 @router.post("/posts/{post_id}/retweet")
 async def retweet_post(post_id: int, data: RetweetRequest):
-    posts = load_posts()
-    post = next((p for p in posts if p["id"] == post_id), None)
+    post = get_post(post_id)
     if not post:
         raise HTTPException(status_code=404, detail="Post not found")
     retweets = post.setdefault("retweets", [])
     if data.user_id not in retweets:
         retweets.append(data.user_id)
-        save_posts(posts)
+        update_post(post)
         await broadcast({"type": "retweet", "post_id": post_id, "retweets": retweets})
     return {"retweets": len(retweets)}
 
 
 @router.post("/posts/{post_id}/unretweet")
 async def unretweet_post(post_id: int, data: RetweetRequest):
-    posts = load_posts()
-    post = next((p for p in posts if p["id"] == post_id), None)
+    post = get_post(post_id)
     if not post:
         raise HTTPException(status_code=404, detail="Post not found")
     retweets = post.setdefault("retweets", [])
     if data.user_id in retweets:
         retweets.remove(data.user_id)
-        save_posts(posts)
+        update_post(post)
         await broadcast({"type": "retweet", "post_id": post_id, "retweets": retweets})
     return {"retweets": len(retweets)}
 


### PR DESCRIPTION
## Summary
- add single-row update helpers in `db.py`
- expose `get_post` and `update_post` via `crud.py`
- switch like/retweet endpoints to use new helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68896fdb278c832da927dcc3575ae516