### PR TITLE
Change icons for community sidebar

### DIFF
--- a/osarebito-frontend/src/components/CommunitySidebar.tsx
+++ b/osarebito-frontend/src/components/CommunitySidebar.tsx
@@ -8,6 +8,8 @@ import {
   BriefcaseIcon,
   SparklesIcon,
   UserGroupIcon,
+  UserIcon,
+  EyeSlashIcon,
   BookmarkIcon,
   PaintBrushIcon,
   PhotoIcon,
@@ -57,7 +59,7 @@ export default function CommunitySidebar() {
         <span>ブックマーク</span>
       </Link>
       <Link href="/community/mypage" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
-        <UserGroupIcon className="w-5 h-5" />
+        <UserIcon className="w-5 h-5" />
         <span>マイページ</span>
       </Link>
       <Link href="/community/jobs" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
@@ -94,7 +96,7 @@ export default function CommunitySidebar() {
           location.href = '/community'
         }}
       >
-        <UserGroupIcon className="w-5 h-5" />
+        <EyeSlashIcon className="w-5 h-5" />
         <span>{anonMode ? '通常モード' : '匿名モード'}</span>
       </button>
     </nav>


### PR DESCRIPTION
## Summary
- replace duplicate icons for the community sidebar
- anonymous mode now uses `EyeSlashIcon`
- my page now uses `UserIcon`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688983ee37e0832d96c0342b5fb7910e