### PR TITLE
Add community settings page

### DIFF
--- a/osarebito-backend/app/routes/users.py
+++ b/osarebito-backend/app/routes/users.py
@@ -224,6 +224,17 @@ def list_following(user_id: str):
     return result
 
 
+@router.get("/users/{user_id}/blocks")
+def list_blocks(user_id: str):
+    users = load_users()
+    target = next((u for u in users if u["user_id"] == user_id), None)
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+    block_ids = target.get("blocks", [])
+    result = [remove_sensitive_fields(u) for u in users if u["user_id"] in block_ids]
+    return result
+
+
 @router.get("/users/{user_id}/bookmarks")
 def list_bookmarks(user_id: str):
     users = load_users()

--- a/osarebito-frontend/src/app/api/users/[userId]/blocks/route.ts
+++ b/osarebito-frontend/src/app/api/users/[userId]/blocks/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { blocksUrl } from '@/routes'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export async function GET(req: NextRequest, { params }: { params: any }) {
+  try {
+    const userId = Array.isArray(params.userId) ? params.userId[0] : params.userId
+    const res = await fetch(blocksUrl(userId))
+    const body = await res.json()
+    if (!res.ok) {
+      return NextResponse.json({ detail: body.detail }, { status: res.status })
+    }
+    return NextResponse.json(body)
+  } catch {
+    return NextResponse.json({ detail: 'Server error' }, { status: 500 })
+  }
+}

--- a/osarebito-frontend/src/app/community/settings/page.tsx
+++ b/osarebito-frontend/src/app/community/settings/page.tsx
@@ -1,0 +1,53 @@
+'use client'
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+
+interface User {
+  user_id: string
+  username?: string
+}
+
+export default function CommunitySettings() {
+  const [blocks, setBlocks] = useState<User[]>([])
+
+  const load = async () => {
+    const uid = localStorage.getItem('userId') || ''
+    if (!uid) return
+    const res = await axios.get(`/api/users/${uid}/blocks`)
+    setBlocks(res.data || [])
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const unblock = async (targetId: string) => {
+    const uid = localStorage.getItem('userId') || ''
+    if (!uid) return
+    await axios.post(`/api/users/${targetId}/unblock`, { user_id: uid })
+    load()
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">コミュニティ設定</h1>
+      <div>
+        <h2 className="font-semibold mb-2">ブロック中のユーザー</h2>
+        <div className="space-y-2">
+          {blocks.map((u) => (
+            <div key={u.user_id} className="flex items-center justify-between border rounded-lg bg-white p-2 shadow">
+              <span>{u.username || u.user_id}</span>
+              <button
+                className="bg-red-500 hover:bg-red-600 text-white rounded px-3"
+                onClick={() => unblock(u.user_id)}
+              >
+                解除
+              </button>
+            </div>
+          ))}
+          {blocks.length === 0 && <p>ブロックしているユーザーはいません。</p>}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/osarebito-frontend/src/components/CommunitySidebar.tsx
+++ b/osarebito-frontend/src/components/CommunitySidebar.tsx
@@ -13,6 +13,7 @@ import {
   BookmarkIcon,
   PaintBrushIcon,
   PhotoIcon,
+  Cog6ToothIcon,
 } from '@heroicons/react/24/outline'
 import { useEffect, useState } from 'react'
 
@@ -77,6 +78,10 @@ export default function CommunitySidebar() {
       <Link href="/community/achievements" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
         <SparklesIcon className="w-5 h-5" />
         <span>実績</span>
+      </Link>
+      <Link href="/community/settings" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">
+        <Cog6ToothIcon className="w-5 h-5" />
+        <span>設定</span>
       </Link>
       {showTutorial && (
         <Link href="/community/tutorial" className="flex items-center gap-2 text-pink-700 hover:text-pink-900">

--- a/osarebito-frontend/src/routes.ts
+++ b/osarebito-frontend/src/routes.ts
@@ -14,6 +14,7 @@ export const mutualFollowersUrl = (userId: string, myId: string) =>
   `${BACKEND_URL}/users/${userId}/mutual_followers?my_id=${myId}`
 export const followersUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/followers`
 export const followingUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/following`
+export const blocksUrl = (userId: string) => `${BACKEND_URL}/users/${userId}/blocks`
 export const postsUrl = (
   feed: string,
   userId?: string,


### PR DESCRIPTION
## Summary
- add endpoint to list blocked users
- add API route and constant
- create community settings page for managing blocked users
- link settings page from sidebar

## Testing
- `npm --prefix osarebito-frontend run lint`
- `git ls-files "*.py" | xargs python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68898f37e72c832d82316e5cacbd5a0a