### PR TITLE
Add reusable post card component

### DIFF
--- a/osarebito-frontend/src/app/community/bookmarks/page.tsx
+++ b/osarebito-frontend/src/app/community/bookmarks/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '@heroicons/react/24/outline'
 import { HeartIcon as HeartIconSolid } from '@heroicons/react/24/solid'
 import ReportModal from '@/components/ReportModal'
+import PostCard from '@/components/PostCard'
 
 interface Post {
   id: number
@@ -104,32 +105,32 @@ export default function CommunityBookmarks() {
         const rted = (p.retweets || []).includes(localStorage.getItem('userId') || '')
         const marked = bookmarks.includes(p.id)
         return (
-          <div key={p.id} className="border rounded-lg bg-white p-4 shadow mb-3">
-            <div className="text-sm text-gray-600">{p.author_id}</div>
-            {p.category && (
-              <div className="text-xs text-pink-600 mb-1">[{p.category}]</div>
-            )}
-            <p>{p.content}</p>
-            {p.image && (
-              <img src={p.image} alt="post image" className="max-h-60 mt-2" />
-            )}
-            <div className="mt-2 flex gap-4 text-sm items-center">
-              <button className="flex items-center gap-1 underline" onClick={() => handleLike(p.id, liked)}>
-                {liked ? <HeartIconSolid className="w-4 h-4 text-red-500" /> : <HeartIcon className="w-4 h-4" />}
-                {p.likes ? p.likes.length : 0}
-              </button>
-              <button className="flex items-center gap-1 underline" onClick={() => handleRetweet(p.id, rted)}>
-                <ArrowsRightLeftIcon className={`w-4 h-4 ${rted ? 'text-blue-500' : ''}`} />
-                {p.retweets ? p.retweets.length : 0}
-              </button>
-              <button className="flex items-center gap-1 underline" onClick={() => handleBookmark(p.id, marked)}>
-                <BookmarkIcon className={`w-4 h-4 ${marked ? 'text-green-500' : ''}`} />
-              </button>
-              <button className="underline text-xs" onClick={() => openReport(p.id)}>
-                通報
-              </button>
-            </div>
-          </div>
+          <PostCard
+            key={p.id}
+            author={p.author_id}
+            category={p.category}
+            content={p.content}
+            image={p.image}
+            createdAt={p.created_at}
+            actions={
+              <>
+                <button className="flex items-center gap-1 underline" onClick={() => handleLike(p.id, liked)}>
+                  {liked ? <HeartIconSolid className="w-4 h-4 text-red-500" /> : <HeartIcon className="w-4 h-4" />}
+                  {p.likes ? p.likes.length : 0}
+                </button>
+                <button className="flex items-center gap-1 underline" onClick={() => handleRetweet(p.id, rted)}>
+                  <ArrowsRightLeftIcon className={`w-4 h-4 ${rted ? 'text-blue-500' : ''}`} />
+                  {p.retweets ? p.retweets.length : 0}
+                </button>
+                <button className="flex items-center gap-1 underline" onClick={() => handleBookmark(p.id, marked)}>
+                  <BookmarkIcon className={`w-4 h-4 ${marked ? 'text-green-500' : ''}`} />
+                </button>
+                <button className="underline text-xs" onClick={() => openReport(p.id)}>
+                  通報
+                </button>
+              </>
+            }
+          />
         )
       })}
       {posts.length === 0 && <p>ブックマークはありません。</p>}

--- a/osarebito-frontend/src/app/community/page.tsx
+++ b/osarebito-frontend/src/app/community/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState, useRef } from 'react'
 import axios from 'axios'
 import Link from 'next/link'
+import PostCard from '@/components/PostCard'
 import { updatesWsUrl, bestAnswerUrl } from '@/routes'
 import {
   HeartIcon,
@@ -340,15 +341,66 @@ export default function CommunityHome() {
           )}
         </div>
         {posts.map((p) => (
-          <div key={p.id} id={`post-${p.id}`} className="rounded-lg bg-white p-4 shadow mb-4">
-            <div className="text-sm text-gray-600">{p.author_id}</div>
-            {p.category && (
-              <div className="text-xs text-pink-600 mb-1">[{p.category}]</div>
-            )}
-            <p>{p.content}</p>
-            {p.image && (
-              <img src={p.image} alt="post image" className="max-h-60 mt-2" />
-            )}
+          <PostCard
+            key={p.id}
+            author={p.author_id}
+            category={p.category}
+            content={p.content}
+            image={p.image}
+            createdAt={p.created_at}
+            actions={
+              <>
+                <button
+                  className="flex items-center gap-1 underline"
+                  onClick={() =>
+                    handleLike(
+                      p.id,
+                      (p.likes || []).includes(localStorage.getItem('userId') || '')
+                    )
+                  }
+                >
+                  {(p.likes || []).includes(localStorage.getItem('userId') || '') ? (
+                    <HeartIconSolid className="w-4 h-4 text-red-500" />
+                  ) : (
+                    <HeartIcon className="w-4 h-4" />
+                  )}
+                  {p.likes ? p.likes.length : 0}
+                </button>
+                <Link
+                  href={`/community/post/${p.id}`}
+                  className="flex items-center gap-1 underline"
+                >
+                  <ChatBubbleLeftIcon className="w-4 h-4" />
+                  {comments[p.id]?.length || 0}
+                </Link>
+                <button
+                  className="flex items-center gap-1 underline"
+                  onClick={() =>
+                    handleRetweet(
+                      p.id,
+                      (p.retweets || []).includes(localStorage.getItem('userId') || '')
+                    )
+                  }
+                >
+                  <ArrowsRightLeftIcon
+                    className={`w-4 h-4 ${(p.retweets || []).includes(localStorage.getItem('userId') || '') ? 'text-blue-500' : ''}`}
+                  />
+                  {p.retweets ? p.retweets.length : 0}
+                </button>
+                <button
+                  className="flex items-center gap-1 underline"
+                  onClick={() => handleBookmark(p.id, bookmarks.includes(p.id))}
+                >
+                  <BookmarkIcon
+                    className={`w-4 h-4 ${bookmarks.includes(p.id) ? 'text-green-500' : ''}`}
+                  />
+                </button>
+                <button className="underline" onClick={() => openReport('post', p.id)}>
+                  通報
+                </button>
+              </>
+            }
+          >
             {p.tags && p.tags.length > 0 && (
               <div className="mt-1 flex flex-wrap gap-2 text-sm text-pink-600">
                 {p.tags.map((t) => (
@@ -356,69 +408,7 @@ export default function CommunityHome() {
                 ))}
               </div>
             )}
-            <div className="mt-2 flex gap-4 text-sm items-center">
-              <button
-                className="flex items-center gap-1 underline"
-                onClick={() =>
-                  handleLike(
-                    p.id,
-                    (p.likes || []).includes(
-                      localStorage.getItem('userId') || '',
-                    ),
-                  )
-                }
-              >
-                {(
-                  p.likes || []
-                ).includes(localStorage.getItem('userId') || '') ? (
-                  <HeartIconSolid className="w-4 h-4 text-red-500" />
-                ) : (
-                  <HeartIcon className="w-4 h-4" />
-                )}
-                {p.likes ? p.likes.length : 0}
-              </button>
-              <Link
-                href={`/community/post/${p.id}`}
-                className="flex items-center gap-1 underline"
-              >
-                <ChatBubbleLeftIcon className="w-4 h-4" />
-                {comments[p.id]?.length || 0}
-              </Link>
-              <button
-                className="flex items-center gap-1 underline"
-                onClick={() =>
-                  handleRetweet(
-                    p.id,
-                    (p.retweets || []).includes(
-                      localStorage.getItem('userId') || '',
-                    ),
-                  )
-                }
-              >
-                <ArrowsRightLeftIcon
-                  className={`w-4 h-4 ${(
-                    p.retweets || []
-                  ).includes(localStorage.getItem('userId') || '') ? 'text-blue-500' : ''}`}
-                />
-                {p.retweets ? p.retweets.length : 0}
-              </button>
-              <button
-                className="flex items-center gap-1 underline"
-                onClick={() => handleBookmark(p.id, bookmarks.includes(p.id))}
-              >
-                <BookmarkIcon
-                  className={`w-4 h-4 ${bookmarks.includes(p.id) ? 'text-green-500' : ''}`}
-                />
-              </button>
-              <button className="underline" onClick={() => openReport('post', p.id)}>
-                通報
-              </button>
-            </div>
-            {/* comments hidden in feed */}
-              <div className="text-right text-xs text-gray-500 mt-1">
-                {new Date(p.created_at).toLocaleString()}
-              </div>
-          </div>
+          </PostCard>
         ))}
       </div>
       <div className="w-72 space-y-6 ml-auto">

--- a/osarebito-frontend/src/app/community/post/[postId]/page.tsx
+++ b/osarebito-frontend/src/app/community/post/[postId]/page.tsx
@@ -11,6 +11,7 @@ import {
 } from '@heroicons/react/24/outline'
 import { HeartIcon as HeartIconSolid } from '@heroicons/react/24/solid'
 import ReportModal from '@/components/ReportModal'
+import PostCard from '@/components/PostCard'
 
 interface Post {
   id: number
@@ -165,57 +166,49 @@ export default function PostCommentsPage() {
         <Link href="/community" className="underline text-sm">
           &larr; 戻る
         </Link>
-        <div className="rounded-lg bg-white p-4 shadow">
-          <div className="text-sm text-gray-600">{post.author_id}</div>
-          {post.category && (
-            <div className="text-xs text-pink-600 mb-1">[{post.category}]</div>
-          )}
-          <p>{post.content}</p>
-          {post.image && (
-            <img src={post.image} alt="post image" className="max-h-60 mt-2" />
-          )}
-          <div className="mt-2 flex gap-4 text-sm items-center">
-            <button className="flex items-center gap-1 underline" onClick={() => handleLike(liked)}>
-            {liked ? (
-              <HeartIconSolid className="w-4 h-4 text-red-500" />
-            ) : (
-              <HeartIcon className="w-4 h-4" />
-            )}
-            {post.likes ? post.likes.length : 0}
-          </button>
-          <button className="flex items-center gap-1 underline" onClick={() => handleRetweet(rted)}>
-            <ArrowsRightLeftIcon className={`w-4 h-4 ${rted ? 'text-blue-500' : ''}`} />
-            {post.retweets ? post.retweets.length : 0}
-          </button>
-          <button className="flex items-center gap-1 underline" onClick={() => handleBookmark(marked)}>
-            <BookmarkIcon className={`w-4 h-4 ${marked ? 'text-green-500' : ''}`} />
-          </button>
-          <button
-            className="underline text-sm"
-            onClick={() => setReportTarget({ type: 'post', id: postId })}
-          >
-            通報
-          </button>
-        </div>
-          <div className="text-right text-xs text-gray-500 mt-1">
-            {new Date(post.created_at).toLocaleString()}
-          </div>
-        </div>
-        <div className="space-y-2">
-          {comments.map((c) => (
-            <div key={c.id} className="rounded-lg bg-white p-2 shadow text-sm">
-              <span className="text-gray-600 mr-2">{c.author_id}</span>
-              {c.content}
-              <span className="ml-2 text-xs text-gray-500">
-                {new Date(c.created_at).toLocaleString()}
-              </span>
-              <button
-                className="ml-2 text-xs underline"
-                onClick={() => openReport('comment', c.id)}
-              >
+        <PostCard
+          author={post.author_id}
+          category={post.category}
+          content={post.content}
+          image={post.image}
+          createdAt={post.created_at}
+          actions={
+            <>
+              <button className="flex items-center gap-1 underline" onClick={() => handleLike(liked)}>
+                {liked ? (
+                  <HeartIconSolid className="w-4 h-4 text-red-500" />
+                ) : (
+                  <HeartIcon className="w-4 h-4" />
+                )}
+                {post.likes ? post.likes.length : 0}
+              </button>
+              <button className="flex items-center gap-1 underline" onClick={() => handleRetweet(rted)}>
+                <ArrowsRightLeftIcon className={`w-4 h-4 ${rted ? 'text-blue-500' : ''}`} />
+                {post.retweets ? post.retweets.length : 0}
+              </button>
+              <button className="flex items-center gap-1 underline" onClick={() => handleBookmark(marked)}>
+                <BookmarkIcon className={`w-4 h-4 ${marked ? 'text-green-500' : ''}`} />
+              </button>
+              <button className="underline text-sm" onClick={() => setReportTarget({ type: 'post', id: postId })}>
                 通報
               </button>
-            </div>
+            </>
+          }
+        />
+        <div className="space-y-2">
+          {comments.map((c) => (
+              <PostCard
+                key={c.id}
+                author={c.author_id}
+                content={c.content}
+                createdAt={c.created_at}
+                compact
+                actions={
+                  <button className="ml-2 text-xs underline" onClick={() => openReport('comment', c.id)}>
+                    通報
+                  </button>
+                }
+              />
           ))}
           <div className="flex gap-2 mt-2">
             <input

--- a/osarebito-frontend/src/components/PostCard.tsx
+++ b/osarebito-frontend/src/components/PostCard.tsx
@@ -1,0 +1,44 @@
+'use client'
+import React from 'react'
+
+interface Props {
+  author: string
+  category?: string | null
+  content: string
+  image?: string | null
+  createdAt: string
+  actions?: React.ReactNode
+  children?: React.ReactNode
+  compact?: boolean
+}
+
+export default function PostCard({
+  author,
+  category,
+  content,
+  image,
+  createdAt,
+  actions,
+  children,
+  compact = false,
+}: Props) {
+  return (
+    <div className={`rounded-lg bg-white shadow ${compact ? 'p-2 text-sm' : 'p-4'}`}>
+      <div className={`${compact ? 'text-xs' : 'text-sm'} text-gray-600`}>{author}</div>
+      {category && !compact && (
+        <div className="text-xs text-pink-600 mb-1">[{category}]</div>
+      )}
+      <p>{content}</p>
+      {image && !compact && (
+        <img src={image} alt="post image" className="max-h-60 mt-2" />
+      )}
+      {children}
+      {actions && (
+        <div className="mt-2 flex gap-4 text-sm items-center">{actions}</div>
+      )}
+      <div className="text-right text-xs text-gray-500 mt-1">
+        {new Date(createdAt).toLocaleString()}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- implement `PostCard` component for community views
- use `PostCard` on community timeline, bookmarks list and post details
- adjust comment cards using compact `PostCard`

## Testing
- `npm --prefix osarebito-frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_688991e55640832d942998121db49430