### PR TITLE
Add user icon to community post cards

### DIFF
--- a/osarebito-frontend/src/components/PostCard.tsx
+++ b/osarebito-frontend/src/components/PostCard.tsx
@@ -1,8 +1,10 @@
 'use client'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import axios from 'axios'
 
 interface Props {
   author: string
+  authorIcon?: string | null
   category?: string | null
   content: string
   image?: string | null
@@ -14,6 +16,7 @@ interface Props {
 
 export default function PostCard({
   author,
+  authorIcon,
   category,
   content,
   image,
@@ -22,9 +25,33 @@ export default function PostCard({
   children,
   compact = false,
 }: Props) {
+  const [icon, setIcon] = useState<string | null>(authorIcon || null)
+
+  useEffect(() => {
+    if (!authorIcon) {
+      axios
+        .get(`/api/users/${author}`)
+        .then((res) => {
+          setIcon(res.data.profile?.profile_image || null)
+        })
+        .catch(() => {
+          /* ignore */
+        })
+    }
+  }, [author, authorIcon])
+
   return (
     <div className={`rounded-lg bg-white shadow ${compact ? 'p-2 text-sm' : 'p-4'}`}>
-      <div className={`${compact ? 'text-xs' : 'text-sm'} text-gray-600`}>{author}</div>
+      <div className={`${compact ? 'text-xs' : 'text-sm'} text-gray-600 flex items-center gap-2`}>
+        {icon && (
+          <img
+            src={icon}
+            alt="icon"
+            className={`${compact ? 'w-4 h-4' : 'w-6 h-6'} rounded-full`}
+          />
+        )}
+        <span>{author}</span>
+      </div>
       {category && !compact && (
         <div className="text-xs text-pink-600 mb-1">[{category}]</div>
       )}


### PR DESCRIPTION
## Summary
- display author's icon next to their ID in post cards

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6889b0c3f670832dadb39f77f79a0ecb