### PR TITLE
Improve async broadcast for faster actions

### DIFF
--- a/osarebito-backend/app/routes/misc.py
+++ b/osarebito-backend/app/routes/misc.py
@@ -42,7 +42,7 @@ from ..crud import (
     save_approval_calendars,
 )
 from ..utils import (
-    broadcast,
+    schedule_broadcast,
     TUTORIAL_TASKS,
     is_semibanned,
     generate_schedule_image,
@@ -81,7 +81,7 @@ async def send_message(msg: MessageCreate):
             notes.append({"type": "message", "from": msg.sender_id, "message_id": new_id, "created_at": item["created_at"]})
             break
     save_users(users)
-    await broadcast({"type": "new_message", "message": item})
+    schedule_broadcast({"type": "new_message", "message": item})
     return item
 
 
@@ -185,7 +185,7 @@ async def send_group_message(group_id: int, msg: GroupMessageCreate):
     }
     messages.append(item)
     save_group_messages(messages)
-    await broadcast({"type": "group_message", "group_id": group_id, "message": item})
+    schedule_broadcast({"type": "group_message", "group_id": group_id, "message": item})
     return item
 
 
@@ -214,7 +214,7 @@ async def create_job(job: JobPostCreate):
     }
     jobs.append(item)
     save_jobs(jobs)
-    await broadcast({"type": "new_job", "job": item})
+    schedule_broadcast({"type": "new_job", "job": item})
     return item
 
 
@@ -413,7 +413,7 @@ async def create_poll(poll: PollCreate):
     }
     polls.append(item)
     save_polls(polls)
-    await broadcast({"type": "new_poll", "poll": item})
+    schedule_broadcast({"type": "new_poll", "poll": item})
     return item
 
 
@@ -443,7 +443,7 @@ async def vote_poll(poll_id: int, req: PollVoteRequest):
     poll["votes"][req.option].append(req.user_id)
     save_polls(polls)
     counts = [len(v) for v in poll["votes"]]
-    await broadcast({"type": "vote", "poll_id": poll_id, "counts": counts})
+    schedule_broadcast({"type": "vote", "poll_id": poll_id, "counts": counts})
     return {"counts": counts}
 
 

--- a/osarebito-backend/app/routes/posts.py
+++ b/osarebito-backend/app/routes/posts.py
@@ -29,7 +29,7 @@ from ..utils import (
     FIRST_COMMENT_ACHIEVEMENT,
     ROLE_REPORT_POINTS,
     REPORT_CATEGORIES,
-    broadcast,
+    schedule_broadcast,
     is_semibanned,
 )
 
@@ -65,7 +65,7 @@ async def create_post(post: PostCreate):
     if first_post:
         add_achievement(user, FIRST_POST_ACHIEVEMENT)
         save_users(users)
-    await broadcast({"type": "new_post", "post": item})
+    schedule_broadcast({"type": "new_post", "post": item})
     return item
 
 
@@ -174,7 +174,7 @@ async def like_post(post_id: int, data: LikeRequest):
     if data.user_id not in likes:
         likes.append(data.user_id)
         update_post(post)
-        await broadcast({"type": "like", "post_id": post_id, "likes": likes})
+        schedule_broadcast({"type": "like", "post_id": post_id, "likes": likes})
     return {"likes": len(likes)}
 
 
@@ -187,7 +187,7 @@ async def unlike_post(post_id: int, data: LikeRequest):
     if data.user_id in likes:
         likes.remove(data.user_id)
         update_post(post)
-        await broadcast({"type": "like", "post_id": post_id, "likes": likes})
+        schedule_broadcast({"type": "like", "post_id": post_id, "likes": likes})
     return {"likes": len(likes)}
 
 
@@ -200,7 +200,7 @@ async def retweet_post(post_id: int, data: RetweetRequest):
     if data.user_id not in retweets:
         retweets.append(data.user_id)
         update_post(post)
-        await broadcast({"type": "retweet", "post_id": post_id, "retweets": retweets})
+        schedule_broadcast({"type": "retweet", "post_id": post_id, "retweets": retweets})
     return {"retweets": len(retweets)}
 
 
@@ -213,7 +213,7 @@ async def unretweet_post(post_id: int, data: RetweetRequest):
     if data.user_id in retweets:
         retweets.remove(data.user_id)
         update_post(post)
-        await broadcast({"type": "retweet", "post_id": post_id, "retweets": retweets})
+        schedule_broadcast({"type": "retweet", "post_id": post_id, "retweets": retweets})
     return {"retweets": len(retweets)}
 
 


### PR DESCRIPTION
## Summary
- optimize broadcast by sending messages concurrently
- send websocket updates asynchronously for likes, reposts, and other actions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889b6404fe0832d977cb35cab5c1c9e