### PR TITLE
Add logging configuration and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 node_modules/
 osarebito-backend/venv/
+*.db

--- a/osarebito-backend/app/config.py
+++ b/osarebito-backend/app/config.py
@@ -1,0 +1,16 @@
+import os
+import logging
+
+
+class Settings:
+    def __init__(self) -> None:
+        self.database_url = os.getenv("DATABASE_URL", "sqlite:///osarebito.db")
+        self.log_level = os.getenv("LOG_LEVEL", "INFO")
+
+
+settings = Settings()
+
+
+def init_logging() -> None:
+    level = getattr(logging, settings.log_level.upper(), logging.INFO)
+    logging.basicConfig(level=level)

--- a/osarebito-backend/app/db.py
+++ b/osarebito-backend/app/db.py
@@ -1,4 +1,3 @@
-import os
 from sqlalchemy import (
     create_engine,
     MetaData,
@@ -12,8 +11,9 @@ from sqlalchemy import (
     delete,
     update,
 )
+from .config import settings
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///osarebito.db")
+DATABASE_URL = settings.database_url
 engine = create_engine(DATABASE_URL)
 metadata = MetaData()
 

--- a/osarebito-backend/app/main.py
+++ b/osarebito-backend/app/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
+from .config import init_logging
 from .routes import users, posts, misc, ws
 
+init_logging()
 app = FastAPI()
 
 app.include_router(users.router)

--- a/osarebito-backend/requirements.txt
+++ b/osarebito-backend/requirements.txt
@@ -1,7 +1,10 @@
-fastapi
-uvicorn[standard]
-python-dotenv
-email-validator
-SQLAlchemy
-psycopg2-binary
-Pillow
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+python-dotenv==1.0.1
+email-validator==2.1.0.post1
+SQLAlchemy==2.0.29
+psycopg2-binary==2.9.9
+Pillow==10.2.0
+PyQt5==5.15.10
+pytest==8.2.2
+httpx==0.27.0

--- a/osarebito-backend/tests/test_openapi.py
+++ b/osarebito-backend/tests/test_openapi.py
@@ -1,0 +1,13 @@
+import os
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+def test_openapi(tmp_path):
+    db_file = tmp_path / "test.db"
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_file}"
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    from app.main import app
+    client = TestClient(app)
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add simple environment-based settings with logging initialization
- configure database URL through settings and ignore SQLite files
- pin dependencies and add basic OpenAPI schema test

## Testing
- `cd osarebito-backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ffb3262d4832dbaf7ba068d278d05